### PR TITLE
Add start-to-end pipeline class

### DIFF
--- a/include/ccglib/ccglib.hpp
+++ b/include/ccglib/ccglib.hpp
@@ -1,4 +1,5 @@
 #include <ccglib/gemm/mma.h>
 #include <ccglib/gemm/reference.h>
 #include <ccglib/packing/packing.h>
+#include <ccglib/pipeline/pipeline.h>
 #include <ccglib/transpose/transpose.h>

--- a/include/ccglib/pipeline/pipeline.h
+++ b/include/ccglib/pipeline/pipeline.h
@@ -28,6 +28,7 @@ public:
            mma::Variant variant = mma::Variant::opt);
   ~Pipeline();
   void Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c);
+  void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
 
 private:
   class Impl;

--- a/include/ccglib/pipeline/pipeline.h
+++ b/include/ccglib/pipeline/pipeline.h
@@ -1,0 +1,41 @@
+#ifndef PIPELINE_H_
+#define PIPELINE_H_
+
+#include <memory>
+
+#include <ccglib/common/complex_order.h>
+#include <ccglib/common/value_precision.h>
+#include <ccglib/gemm/mem_order.h>
+#include <ccglib/gemm/variant.h>
+
+// Forward declaration of cudawrappers types
+namespace cu {
+class Device;
+class HostMemory;
+class Stream;
+} // namespace cu
+
+namespace ccglib::pipeline {
+
+class Pipeline {
+public:
+  Pipeline(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
+           cu::Stream &stream, ComplexAxisLocation input_complex_axis_location,
+           ComplexAxisLocation output_complex_axis_location,
+           mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
+           mma::MemOrder c_mem_order, ValuePrecision input_precision,
+           ValuePrecision output_precision,
+           mma::Variant variant = mma::Variant::opt);
+  ~Pipeline();
+  void Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c);
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+  std::unique_ptr<cu::Device> device_;
+  std::unique_ptr<cu::Stream> stream_;
+};
+
+} // namespace ccglib::pipeline
+
+#endif // PIPELINE_H_

--- a/include/ccglib/pipeline/pipeline.h
+++ b/include/ccglib/pipeline/pipeline.h
@@ -3,6 +3,12 @@
 
 #include <memory>
 
+#ifdef __HIP__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#endif
+
 #include <ccglib/common/complex_order.h>
 #include <ccglib/common/value_precision.h>
 #include <ccglib/gemm/mem_order.h>
@@ -29,6 +35,26 @@ public:
   ~Pipeline();
   void Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c);
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
+
+#ifdef __HIP__
+  Pipeline(size_t B, size_t M, size_t N, size_t K, hipDevice_t &device,
+           hipStream_t &stream, ComplexAxisLocation input_complex_axis_location,
+           ComplexAxisLocation output_complex_axis_location,
+           mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
+           mma::MemOrder c_mem_order, ValuePrecision input_precision,
+           ValuePrecision output_precision,
+           mma::Variant variant = mma::Variant::opt);
+  void Run(hipDeviceptr_t a, hipDeviceptr_t b, hipDeviceptr_t c);
+#else
+  Pipeline(size_t B, size_t M, size_t N, size_t K, CUdevice &device,
+           CUstream &stream, ComplexAxisLocation input_complex_axis_location,
+           ComplexAxisLocation output_complex_axis_location,
+           mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
+           mma::MemOrder c_mem_order, ValuePrecision input_precision,
+           ValuePrecision output_precision,
+           mma::Variant variant = mma::Variant::opt);
+  void Run(CUdeviceptr a, CUdeviceptr b, CUdeviceptr c);
+#endif
 
 private:
   class Impl;

--- a/include/ccglib/pipeline/pipeline.h
+++ b/include/ccglib/pipeline/pipeline.h
@@ -18,6 +18,7 @@
 namespace cu {
 class Device;
 class HostMemory;
+class DeviceMemory;
 class Stream;
 } // namespace cu
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,12 +7,14 @@ add_subdirectory(reference)
 add_subdirectory(mma)
 add_subdirectory(transpose)
 add_subdirectory(packing)
+add_subdirectory(pipeline)
 
 # Link the main library
 add_library(
   ${PROJECT_NAME} SHARED
   $<TARGET_OBJECTS:gemm-reference> $<TARGET_OBJECTS:transpose>
-  $<TARGET_OBJECTS:gemm-mma> $<TARGET_OBJECTS:packing>)
+  $<TARGET_OBJECTS:gemm-mma> $<TARGET_OBJECTS:packing>
+  $<TARGET_OBJECTS:pipeline>)
 
 target_link_libraries(ccglib PUBLIC cudawrappers::cu cudawrappers::nvrtc)
 target_link_libraries(ccglib PRIVATE OpenMP::OpenMP_CXX xtensor)

--- a/src/pipeline/CMakeLists.txt
+++ b/src/pipeline/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(pipeline)
+
+add_library(${PROJECT_NAME} OBJECT Pipeline.cpp)
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${CCGLIB_INCLUDE_DIR})
+
+target_link_libraries(${PROJECT_NAME} PRIVATE cudawrappers::cu
+                                              cudawrappers::nvrtc)
+
+if(${CCGLIB_BACKEND_HIP})
+  get_target_property(sources ${PROJECT_NAME} SOURCES)
+  set_source_files_properties(${sources} PROPERTIES LANGUAGE HIP)
+endif()

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -1,0 +1,49 @@
+#include <cudawrappers/cu.hpp>
+
+#include <ccglib/gemm/mma.h>
+#include <ccglib/packing/packing.h>
+#include <ccglib/pipeline/pipeline.h>
+#include <ccglib/transpose/transpose.h>
+
+namespace ccglib::pipeline {
+
+class Pipeline::Impl {
+public:
+  Impl(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
+       cu::Stream &stream, ComplexAxisLocation input_complex_axis_location,
+       ComplexAxisLocation output_complex_axis_location,
+       mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
+       mma::MemOrder c_mem_order, ValuePrecision input_precision,
+       ValuePrecision output_precision, mma::Variant variant) {}
+
+  void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b,
+           cu::DeviceMemory &d_c) {}
+};
+
+Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
+                   cu::Stream &stream,
+                   ComplexAxisLocation input_complex_axis_location,
+                   ComplexAxisLocation output_complex_axis_location,
+                   mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
+                   mma::MemOrder c_mem_order, ValuePrecision input_precision,
+                   ValuePrecision output_precision, mma::Variant variant)
+    : device_(std::make_unique<cu::Device>(device)),
+      stream_(std::make_unique<cu::Stream>(stream)) {
+  impl_ = std::make_unique<Impl>(
+      B, M, N, K, *device_, *stream_, input_complex_axis_location,
+      output_complex_axis_location, a_mem_order, b_mem_order, c_mem_order,
+      input_precision, output_precision, variant);
+}
+
+void Pipeline::Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c) {
+  cu::DeviceMemory d_a(a.size());
+  cu::DeviceMemory d_b(b.size());
+  cu::DeviceMemory d_c(c.size());
+  stream_->memcpyHtoDAsync(d_a, a, a.size());
+  stream_->memcpyHtoDAsync(d_b, b, b.size());
+  impl_->Run(d_a, d_b, d_c);
+  stream_->memcpyDtoHAsync(c, d_c, c.size());
+  stream_->synchronize();
+}
+
+} // namespace ccglib::pipeline

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -178,4 +178,6 @@ void Pipeline::Run(CUdeviceptr d_a, CUdeviceptr d_b, CUdeviceptr d_c) {
   impl_->Run(d_a_, d_b_, d_c_);
 }
 
+Pipeline::~Pipeline() = default;
+
 } // namespace ccglib::pipeline

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -25,6 +25,7 @@ private:
   static const size_t kComplex = 2;
   const bool needs_packing_;
   const bool needs_transpose_;
+  const ComplexAxisLocation input_complex_axis_location_;
 
   cu::Device device_;
   cu::Stream stream_;
@@ -50,7 +51,8 @@ Pipeline::Impl::Impl(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
                      ValuePrecision output_precision, mma::Variant variant)
     : needs_packing_(input_precision == ccglib::int1),
       needs_transpose_(variant == ccglib::mma::opt), device_(device),
-      stream_(stream) {
+      stream_(stream),
+      input_complex_axis_location_(input_complex_axis_location) {
 
   if (needs_packing_) {
     const size_t num_a = B * kComplex * M * K;
@@ -77,10 +79,10 @@ Pipeline::Impl::Impl(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
   if (needs_transpose_) {
     transpose_a_ = std::make_unique<ccglib::transpose::Transpose>(
         B, M, K, dimensions.x, dimensions.z, precision.GetInputBits(), device_,
-        stream_, input_complex_axis_location);
+        stream_, input_complex_axis_location_);
     transpose_b_ = std::make_unique<ccglib::transpose::Transpose>(
         B, N, K, dimensions.y, dimensions.z, precision.GetOutputBits(), device_,
-        stream_, input_complex_axis_location);
+        stream_, input_complex_axis_location_);
 
     // transposed size may be bigger than input due to padding on block level
     const size_t m_padded =
@@ -102,7 +104,26 @@ Pipeline::Impl::Impl(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
 }
 
 void Pipeline::Impl::Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b,
-                         cu::DeviceMemory &d_c) {}
+                         cu::DeviceMemory &d_c) {
+
+  if (needs_packing_) {
+    packing_a_->Run(d_a, *d_a_packed_, ccglib::forward,
+                    input_complex_axis_location_);
+    packing_b_->Run(d_b, *d_b_packed_, ccglib::forward,
+                    input_complex_axis_location_);
+  }
+
+  if (needs_transpose_) {
+    cu::DeviceMemory &input_a = needs_packing_ ? *d_a_packed_ : d_a;
+    cu::DeviceMemory &input_b = needs_packing_ ? *d_b_packed_ : d_b;
+    transpose_a_->Run(input_a, *d_a_trans_);
+    transpose_b_->Run(input_b, *d_b_trans_);
+  }
+
+  cu::DeviceMemory &input_a = needs_transpose_ ? *d_a_trans_ : d_a;
+  cu::DeviceMemory &input_b = needs_transpose_ ? *d_b_trans_ : d_b;
+  gemm_->Run(input_a, input_b, d_c);
+}
 
 Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
                    cu::Stream &stream,

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -46,4 +46,9 @@ void Pipeline::Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c) {
   stream_->synchronize();
 }
 
+void Pipeline::Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b,
+                   cu::DeviceMemory &d_c) {
+  impl_->Run(d_a, d_b, d_c);
+}
+
 } // namespace ccglib::pipeline

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -1,5 +1,8 @@
+#include <limits>
+
 #include <cudawrappers/cu.hpp>
 
+#include <ccglib/common/helper.h>
 #include <ccglib/gemm/mma.h>
 #include <ccglib/packing/packing.h>
 #include <ccglib/pipeline/pipeline.h>
@@ -14,11 +17,92 @@ public:
        ComplexAxisLocation output_complex_axis_location,
        mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
        mma::MemOrder c_mem_order, ValuePrecision input_precision,
-       ValuePrecision output_precision, mma::Variant variant) {}
+       ValuePrecision output_precision, mma::Variant variant);
 
-  void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b,
-           cu::DeviceMemory &d_c) {}
+  void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
+
+private:
+  static const size_t kComplex = 2;
+  const bool needs_packing_;
+  const bool needs_transpose_;
+
+  cu::Device device_;
+  cu::Stream stream_;
+
+  std::unique_ptr<cu::DeviceMemory> d_a_packed_;
+  std::unique_ptr<cu::DeviceMemory> d_b_packed_;
+  std::unique_ptr<cu::DeviceMemory> d_a_trans_;
+  std::unique_ptr<cu::DeviceMemory> d_b_trans_;
+
+  std::unique_ptr<ccglib::packing::Packing> packing_a_;
+  std::unique_ptr<ccglib::packing::Packing> packing_b_;
+  std::unique_ptr<ccglib::transpose::Transpose> transpose_a_;
+  std::unique_ptr<ccglib::transpose::Transpose> transpose_b_;
+  std::unique_ptr<ccglib::mma::GEMM> gemm_;
 };
+
+Pipeline::Impl::Impl(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
+                     cu::Stream &stream,
+                     ComplexAxisLocation input_complex_axis_location,
+                     ComplexAxisLocation output_complex_axis_location,
+                     mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
+                     mma::MemOrder c_mem_order, ValuePrecision input_precision,
+                     ValuePrecision output_precision, mma::Variant variant)
+    : needs_packing_(input_precision == ccglib::int1),
+      needs_transpose_(variant == ccglib::mma::opt), device_(device),
+      stream_(stream) {
+
+  if (needs_packing_) {
+    const size_t num_a = B * kComplex * M * K;
+    const size_t num_b = B * kComplex * N * K;
+    packing_a_ =
+        std::make_unique<ccglib::packing::Packing>(num_a, device_, stream_);
+    packing_b_ = std::make_unique<ccglib::packing::Packing>(
+        num_b * kComplex * N * K, device_, stream_);
+
+    // packing output is of int32 type, so round up input size to multiple of
+    // int32 size.
+    const size_t bytes_packed_a =
+        sizeof(int) * ccglib::helper::ceildiv(num_a / CHAR_BIT, sizeof(int));
+    const size_t bytes_packed_b =
+        sizeof(int) * ccglib::helper::ceildiv(num_b / CHAR_BIT, sizeof(int));
+    d_a_packed_ = std::make_unique<cu::DeviceMemory>(bytes_packed_a);
+    d_b_packed_ = std::make_unique<cu::DeviceMemory>(bytes_packed_b);
+  }
+
+  const Precision precision(input_precision, output_precision);
+  // x, y, z = m_per_block, n_per_block, k_per_wmma
+  const dim3 dimensions = ccglib::mma::GEMM::GetDimensions(precision, variant);
+
+  if (needs_transpose_) {
+    transpose_a_ = std::make_unique<ccglib::transpose::Transpose>(
+        B, M, K, dimensions.x, dimensions.z, precision.GetInputBits(), device_,
+        stream_, input_complex_axis_location);
+    transpose_b_ = std::make_unique<ccglib::transpose::Transpose>(
+        B, N, K, dimensions.y, dimensions.z, precision.GetOutputBits(), device_,
+        stream_, input_complex_axis_location);
+
+    // transposed size may be bigger than input due to padding on block level
+    const size_t m_padded =
+        dimensions.x * ccglib::helper::ceildiv(M, dimensions.x);
+    const size_t n_padded =
+        dimensions.y * ccglib::helper::ceildiv(N, dimensions.y);
+    const size_t k_padded =
+        dimensions.z * ccglib::helper::ceildiv(K, dimensions.y);
+    const size_t bytes_trans_a = B * kComplex * m_padded * k_padded;
+    const size_t bytes_trans_b = B * kComplex * n_padded * k_padded;
+
+    d_a_trans_ = std::make_unique<cu::DeviceMemory>(bytes_trans_a);
+    d_b_trans_ = std::make_unique<cu::DeviceMemory>(bytes_trans_b);
+  }
+
+  gemm_ = std::make_unique<ccglib::mma::GEMM>(
+      B, M, N, K, device_, stream_, precision, variant,
+      output_complex_axis_location, c_mem_order, a_mem_order, b_mem_order);
+}
+
+void Pipeline::Impl::Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b,
+                         cu::DeviceMemory &d_c) {}
 
 Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
                    cu::Stream &stream,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,8 +40,10 @@ target_link_libraries(test-transpose PRIVATE ccglib cudawrappers::cu
 add_executable(test-pipeline pipeline/pipeline.cpp)
 target_include_directories(
   test-pipeline PRIVATE ${CMAKE_BINARY_DIR} "${PROJECT_SOURCE_DIR}/include")
+target_include_directories(test-pipeline
+                           PRIVATE "${PROJECT_SOURCE_DIR}/test/gemm")
 target_link_libraries(test-pipeline PRIVATE ccglib cudawrappers::cu
-                                            Catch2::Catch2WithMain)
+                                            Catch2::Catch2WithMain xtensor)
 
 set(TESTS test-helper test-reference test-mma test-packing test-transpose
           test-pipeline)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,14 @@ target_include_directories(
 target_link_libraries(test-transpose PRIVATE ccglib cudawrappers::cu
                                              Catch2::Catch2WithMain xtensor)
 
-set(TESTS test-helper test-reference test-mma test-packing test-transpose)
+add_executable(test-pipeline pipeline/pipeline.cpp)
+target_include_directories(
+  test-pipeline PRIVATE ${CMAKE_BINARY_DIR} "${PROJECT_SOURCE_DIR}/include")
+target_link_libraries(test-pipeline PRIVATE ccglib cudawrappers::cu
+                                            Catch2::Catch2WithMain)
+
+set(TESTS test-helper test-reference test-mma test-packing test-transpose
+          test-pipeline)
 
 # cuda-specific tests
 if(${CCGLIB_BACKEND_CUDA})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,14 @@ if(${CCGLIB_BACKEND_CUDA})
     test-transpose-cuda PRIVATE ccglib Catch2::Catch2WithMain CUDA::cudart
                                 xtensor)
 
-  list(APPEND TESTS test-mma-cuda test-packing-cuda test-transpose-cuda)
+  add_executable(test-pipeline-cuda cuda/pipeline.cpp)
+  target_include_directories(test-pipeline-cuda
+                             PRIVATE "${PROJECT_SOURCE_DIR}/test/gemm")
+  target_link_libraries(test-pipeline-cuda
+                        PRIVATE ccglib Catch2::Catch2WithMain CUDA::cudart)
+
+  list(APPEND TESTS test-mma-cuda test-packing-cuda test-transpose-cuda
+       test-pipeline-cuda)
 endif()
 
 # hip-specific tests
@@ -82,7 +89,13 @@ if(${CCGLIB_BACKEND_HIP})
   target_link_libraries(test-transpose-hip
                         PRIVATE ccglib Catch2::Catch2WithMain xtensor)
 
-  list(APPEND TESTS test-mma-hip test-packing-hip test-transpose-hip)
+  add_executable(test-pipeline-hip hip/pipeline.cpp)
+  target_include_directories(test-pipeline-hip
+                             PRIVATE "${PROJECT_SOURCE_DIR}/test/gemm")
+  target_link_libraries(test-pipeline-hip PRIVATE ccglib Catch2::Catch2WithMain)
+
+  list(APPEND TESTS test-mma-hip test-packing-hip test-transpose-hip
+       test-pipeline-hip)
 endif()
 
 foreach(test IN ITEMS ${TESTS})

--- a/test/cuda/pipeline.cpp
+++ b/test/cuda/pipeline.cpp
@@ -1,0 +1,109 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <ccglib/pipeline/pipeline.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include "fpequals.h"
+
+static inline void cuda_check(cudaError_t err) {
+  if (err != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(err));
+  }
+}
+
+static inline void cu_check(CUresult err) {
+  if (err != CUDA_SUCCESS) {
+    const char *err_str;
+    cuGetErrorString(err, &err_str);
+    throw std::runtime_error(err_str);
+  }
+}
+
+namespace ccglib::test {
+
+TEST_CASE("CUDA pipeline") {
+  cuda_check(cudaFree(0));
+  CUcontext context;
+  cu_check(cuCtxGetCurrent(&context));
+  CUdevice device;
+  cu_check(cuDeviceGet(&device, 0));
+  CUstream stream;
+  cu_check(cuStreamCreate(&stream, CU_STREAM_DEFAULT));
+
+  const size_t global_m = 512;
+  const size_t global_n = 512;
+  const size_t global_k = 512;
+  const size_t batch_size = 3;
+  const size_t COMPLEX = 2;
+
+  using Tin = half;
+  using Tout = float;
+  const ccglib::ValuePrecision input_precision = ccglib::float16;
+  const ccglib::ValuePrecision output_precision = ccglib::float32;
+
+  ccglib::pipeline::Pipeline pipeline(
+      batch_size, global_m, global_n, global_k, device, stream,
+      ccglib::complex_planar, ccglib::complex_planar, ccglib::mma::row_major,
+      ccglib::mma::col_major, ccglib::mma::row_major, input_precision,
+      output_precision, ccglib::mma::opt);
+
+  const size_t bytes_a =
+      sizeof(Tin) * batch_size * COMPLEX * global_m * global_k;
+  const size_t bytes_b =
+      sizeof(Tin) * batch_size * COMPLEX * global_n * global_k;
+  const size_t bytes_c =
+      sizeof(Tout) * batch_size * COMPLEX * global_m * global_n;
+
+  Tin *h_a;
+  Tin *h_b;
+  Tout *h_c;
+
+  cuda_check(cudaMallocHost(&h_a, bytes_a));
+  cuda_check(cudaMallocHost(&h_b, bytes_b));
+  cuda_check(cudaMallocHost(&h_c, bytes_c));
+
+  Tin *d_a;
+  Tin *d_b;
+  Tout *d_c;
+
+  cuda_check(cudaMalloc(&d_a, bytes_a));
+  cuda_check(cudaMalloc(&d_b, bytes_b));
+  cuda_check(cudaMalloc(&d_c, bytes_c));
+
+  for (size_t i = 0; i < batch_size * COMPLEX * global_m * global_k; i++) {
+    h_a[i] = static_cast<Tin>(1);
+  }
+
+  for (size_t i = 0; i < batch_size * COMPLEX * global_n * global_k; i++) {
+    h_b[i] = static_cast<Tin>(1);
+  }
+
+  cuda_check(cudaMemcpy(d_a, h_a, bytes_a, cudaMemcpyHostToDevice));
+  cuda_check(cudaMemcpy(d_b, h_b, bytes_b, cudaMemcpyHostToDevice));
+
+  pipeline.Run(reinterpret_cast<CUdeviceptr>(d_a),
+               reinterpret_cast<CUdeviceptr>(d_b),
+               reinterpret_cast<CUdeviceptr>(d_c));
+
+  cuda_check(cudaMemcpy(h_c, d_c, bytes_c, cudaMemcpyDeviceToHost));
+
+  // with all inputs one, the C matrix has zero for the real part and 2*K for
+  // the imaginary part
+  for (size_t i = 0; i < batch_size * COMPLEX * global_m * global_n; i++) {
+    const size_t index = i % (global_m * global_n);
+    const Tout expected_value =
+        index < global_m * global_n ? 0.0f : 2.0f * global_k;
+    ccglib::test::fpEquals(h_c[index], expected_value);
+  }
+
+  cuda_check(cudaFree(d_a));
+  cuda_check(cudaFree(d_b));
+  cuda_check(cudaFree(d_c));
+
+  cuda_check(cudaFreeHost(h_a));
+  cuda_check(cudaFreeHost(h_b));
+  cuda_check(cudaFreeHost(h_c));
+}
+
+} // namespace ccglib::test

--- a/test/hip/pipeline.cpp
+++ b/test/hip/pipeline.cpp
@@ -1,0 +1,98 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <ccglib/pipeline/pipeline.h>
+#include <hip/hip_runtime.h>
+
+#include "fpequals.h"
+
+static inline void hip_check(hipError_t err) {
+  if (err != hipSuccess) {
+    throw std::runtime_error(hipGetErrorString(err));
+  }
+}
+
+namespace ccglib::test {
+
+TEST_CASE("HIP pipeline") {
+  hip_check(hipInit(0));
+  hipDevice_t device;
+  hip_check(hipDeviceGet(&device, 0));
+  hipStream_t stream;
+  hip_check(hipStreamCreate(&stream));
+
+  const size_t global_m = 512;
+  const size_t global_n = 512;
+  const size_t global_k = 512;
+  const size_t batch_size = 3;
+  const size_t COMPLEX = 2;
+
+  using Tin = half;
+  using Tout = float;
+  const ccglib::ValuePrecision input_precision = ccglib::float16;
+  const ccglib::ValuePrecision output_precision = ccglib::float32;
+
+  ccglib::pipeline::Pipeline pipeline(
+      batch_size, global_m, global_n, global_k, device, stream,
+      ccglib::complex_planar, ccglib::complex_planar, ccglib::mma::row_major,
+      ccglib::mma::col_major, ccglib::mma::row_major, input_precision,
+      output_precision, ccglib::mma::opt);
+
+  const size_t bytes_a =
+      sizeof(Tin) * batch_size * COMPLEX * global_m * global_k;
+  const size_t bytes_b =
+      sizeof(Tin) * batch_size * COMPLEX * global_n * global_k;
+  const size_t bytes_c =
+      sizeof(Tout) * batch_size * COMPLEX * global_m * global_n;
+
+  Tin *h_a;
+  Tin *h_b;
+  Tout *h_c;
+
+  hip_check(hipHostMalloc(&h_a, bytes_a));
+  hip_check(hipHostMalloc(&h_b, bytes_b));
+  hip_check(hipHostMalloc(&h_c, bytes_c));
+
+  Tin *d_a;
+  Tin *d_b;
+  Tout *d_c;
+
+  hip_check(hipMalloc(&d_a, bytes_a));
+  hip_check(hipMalloc(&d_b, bytes_b));
+  hip_check(hipMalloc(&d_c, bytes_c));
+
+  for (size_t i = 0; i < batch_size * COMPLEX * global_m * global_k; i++) {
+    h_a[i] = static_cast<Tin>(1);
+  }
+
+  for (size_t i = 0; i < batch_size * COMPLEX * global_n * global_k; i++) {
+    h_b[i] = static_cast<Tin>(1);
+  }
+
+  hip_check(hipMemcpy(d_a, h_a, bytes_a, hipMemcpyHostToDevice));
+  hip_check(hipMemcpy(d_b, h_b, bytes_b, hipMemcpyHostToDevice));
+
+  pipeline.Run(reinterpret_cast<hipDeviceptr_t>(d_a),
+               reinterpret_cast<hipDeviceptr_t>(d_b),
+               reinterpret_cast<hipDeviceptr_t>(d_c));
+
+  hip_check(hipMemcpy(h_c, d_c, bytes_c, hipMemcpyDeviceToHost));
+
+  // with all inputs one, the C matrix has zero for the real part and 2*K for
+  // the imaginary part
+  for (size_t i = 0; i < batch_size * COMPLEX * global_m * global_n; i++) {
+    const size_t index = i % (global_m * global_n);
+    const Tout expected_value =
+        index < global_m * global_n ? 0.0f : 2.0f * global_k;
+    ccglib::test::fpEquals(h_c[index], expected_value);
+  }
+
+  hip_check(hipFree(d_a));
+  hip_check(hipFree(d_b));
+  hip_check(hipFree(d_c));
+
+  hip_check(hipHostFree(h_a));
+  hip_check(hipHostFree(h_b));
+  hip_check(hipHostFree(h_c));
+}
+
+} // namespace ccglib::test

--- a/test/pipeline/pipeline.cpp
+++ b/test/pipeline/pipeline.cpp
@@ -23,7 +23,7 @@ TEST_CASE("Pipeline") {
 
   const size_t num_a = B * 2 * M * K;
   const size_t num_b = B * 2 * N * K;
-  const size_t num_c = B * 2 * M * K;
+  const size_t num_c = B * 2 * M * N;
 
   cu::init();
   cu::Device device(0);
@@ -44,9 +44,11 @@ TEST_CASE("Pipeline") {
     static_cast<Tin *>(h_b)[i] = generator();
   }
 
-  cu::DeviceMemory d_a(h_a);
-  cu::DeviceMemory d_b(h_b);
+  cu::DeviceMemory d_a(h_a.size());
+  cu::DeviceMemory d_b(h_b.size());
   cu::DeviceMemory d_c(h_c.size());
+  stream.memcpyHtoDAsync(d_a, h_a, d_a.size());
+  stream.memcpyHtoDAsync(d_b, h_b, d_b.size());
   d_c.zero(d_c.size());
 
   ccglib::pipeline::Pipeline pipeline(

--- a/test/pipeline/pipeline.cpp
+++ b/test/pipeline/pipeline.cpp
@@ -77,6 +77,10 @@ TEST_CASE("Pipeline float16 - float32") {
 }
 
 TEST_CASE("Pipeline int1 - int32") {
+#ifdef __HIP_PLATFORM_AMD__
+  SKIP("int1 is not available on AMD GPUs");
+#endif
+
   const size_t B = 2;
   const size_t M = 512;
   const size_t N = 512;

--- a/test/pipeline/pipeline.cpp
+++ b/test/pipeline/pipeline.cpp
@@ -5,14 +5,15 @@
 #include <limits.h>
 #include <random>
 
-#include <ccglib/fp16.h>
+#include <ccglib/common/helper.h>
+#include <ccglib/packing/packing.h>
 #include <ccglib/pipeline/pipeline.h>
 
 #include "verify.h"
 
 namespace ccglib::test {
 
-TEST_CASE("Pipeline") {
+TEST_CASE("Pipeline float16 - float32") {
   const size_t B = 2;
   const size_t M = 300;
   const size_t N = 200;
@@ -73,6 +74,93 @@ TEST_CASE("Pipeline") {
   verify<Tin, Tout, input_precision>(
       static_cast<const Tin *>(h_a), static_cast<const Tin *>(h_b),
       static_cast<Tout *>(h_c), B, M, N, K, c_mem_order);
+}
+
+TEST_CASE("Pipeline int1 - int32") {
+  const size_t B = 2;
+  const size_t M = 512;
+  const size_t N = 512;
+  const size_t K = 512;
+
+  using Tin = unsigned char;
+  using Tpacked = unsigned;
+  using Tout = int;
+  const ccglib::ValueType input_precision = ccglib::int1;
+  const ccglib::ValueType output_precision = ccglib::int32;
+  const ccglib::ComplexAxisLocation input_complex_axis_location =
+      ccglib::complex_planar;
+  const ccglib::ComplexAxisLocation output_complex_axis_location =
+      ccglib::complex_planar;
+  const ccglib::mma::MemOrder a_mem_order = ccglib::mma::row_major;
+  const ccglib::mma::MemOrder b_mem_order = ccglib::mma::col_major;
+  const ccglib::mma::MemOrder c_mem_order = ccglib::mma::row_major;
+  const ccglib::mma::Variant variant = ccglib::mma::opt;
+
+  const size_t num_a = B * 2 * M * K;
+  const size_t num_b = B * 2 * N * K;
+  const size_t num_c = B * 2 * M * N;
+
+  const size_t bytes_a_packed =
+      sizeof(Tpacked) *
+      ccglib::helper::ceildiv(num_a / CHAR_BIT, sizeof(Tpacked));
+  const size_t bytes_a = bytes_a_packed * CHAR_BIT;
+  const size_t bytes_b_packed =
+      sizeof(Tpacked) *
+      ccglib::helper::ceildiv(num_b / CHAR_BIT, sizeof(Tpacked));
+  const size_t bytes_b = bytes_b_packed * CHAR_BIT;
+
+  cu::init();
+  cu::Device device(0);
+  cu::Context context(CU_CTX_BLOCKING_SYNC, device);
+  cu::Stream stream;
+
+  cu::HostMemory h_a_packed(bytes_a_packed);
+  cu::HostMemory h_b_packed(bytes_b_packed);
+  cu::HostMemory h_c(num_c * sizeof(Tout));
+
+  // the reference GEMM used in output verification does not support packing.
+  // As a workaround, we generate random packed data and use the unpacking
+  // kernel to create the data given as input to the pipeline.
+  auto generator =
+      std::bind(std::uniform_int_distribution<Tpacked>(0, UINT_MAX),
+                std::default_random_engine());
+  for (int i = 0; i < bytes_a_packed / sizeof(Tpacked); i++) {
+    static_cast<Tpacked *>(h_a_packed)[i] = generator();
+  }
+
+  for (int i = 0; i < bytes_b_packed / sizeof(Tpacked); i++) {
+    static_cast<Tpacked *>(h_b_packed)[i] = generator();
+  }
+
+  cu::DeviceMemory d_a_packed(h_a_packed.size());
+  cu::DeviceMemory d_b_packed(h_b_packed.size());
+  cu::DeviceMemory d_a(bytes_a);
+  cu::DeviceMemory d_b(bytes_b);
+
+  stream.memcpyHtoDAsync(d_a_packed, h_a_packed, d_a_packed.size());
+  stream.memcpyHtoDAsync(d_b_packed, h_b_packed, d_b_packed.size());
+
+  ccglib::packing::Packing pack_a(num_a, device, stream);
+  ccglib::packing::Packing pack_b(num_a, device, stream);
+  pack_a.Run(d_a_packed, d_a, ccglib::backward, input_complex_axis_location);
+  pack_b.Run(d_b_packed, d_b, ccglib::backward, input_complex_axis_location);
+
+  cu::DeviceMemory d_c(h_c.size());
+  d_c.zero(d_c.size());
+
+  ccglib::pipeline::Pipeline pipeline(
+      B, M, N, K, device, stream, input_complex_axis_location,
+      output_complex_axis_location, a_mem_order, b_mem_order, c_mem_order,
+      input_precision, output_precision, variant);
+
+  pipeline.Run(d_a, d_b, d_c);
+  stream.memcpyDtoHAsync(h_c, d_c, d_c.size());
+  stream.synchronize();
+
+  verify<Tpacked, Tout, input_precision>(
+      static_cast<const Tpacked *>(h_a_packed),
+      static_cast<const Tpacked *>(h_b_packed), static_cast<Tout *>(h_c), B, M,
+      N, K, c_mem_order);
 }
 
 } // namespace ccglib::test

--- a/test/pipeline/pipeline.cpp
+++ b/test/pipeline/pipeline.cpp
@@ -1,0 +1,67 @@
+
+#include <catch2/catch_test_macros.hpp>
+#include <cudawrappers/cu.hpp>
+#include <functional>
+#include <limits.h>
+#include <random>
+
+#include <ccglib/fp16.h>
+#include <ccglib/pipeline/pipeline.h>
+
+#include "verify.h"
+
+namespace ccglib::test {
+
+TEST_CASE("Pipeline") {
+  const size_t B = 1;
+  const size_t M = 512;
+  const size_t N = 512;
+  const size_t K = 512;
+
+  using Tin = half;
+  using Tout = float;
+
+  const size_t num_a = B * 2 * M * K;
+  const size_t num_b = B * 2 * N * K;
+  const size_t num_c = B * 2 * M * K;
+
+  cu::init();
+  cu::Device device(0);
+  cu::Context context(CU_CTX_BLOCKING_SYNC, device);
+  cu::Stream stream;
+
+  cu::HostMemory h_a(num_a * sizeof(Tin));
+  cu::HostMemory h_b(num_b * sizeof(Tin));
+  cu::HostMemory h_c(num_c * sizeof(Tout));
+
+  auto generator = std::bind(std::uniform_real_distribution<float>(-10, 10),
+                             std::default_random_engine());
+  for (int i = 0; i < num_a; i++) {
+    static_cast<Tin *>(h_a)[i] = generator();
+  }
+
+  for (int i = 0; i < num_b; i++) {
+    static_cast<Tin *>(h_b)[i] = generator();
+  }
+
+  cu::DeviceMemory d_a(h_a);
+  cu::DeviceMemory d_b(h_b);
+  cu::DeviceMemory d_c(h_c.size());
+  d_c.zero(d_c.size());
+
+  ccglib::pipeline::Pipeline pipeline(
+      B, M, N, K, device, stream, ccglib::complex_planar,
+      ccglib::complex_planar, ccglib::mma::row_major, ccglib::mma::col_major,
+      ccglib::mma::row_major, ccglib::float16, ccglib::float32,
+      ccglib::mma::opt);
+
+  pipeline.Run(d_a, d_b, d_c);
+  stream.memcpyDtoHAsync(h_c, d_c, d_c.size());
+  stream.synchronize();
+
+  verify<Tin, Tout, ccglib::float16>(
+      static_cast<const Tin *>(h_a), static_cast<const Tin *>(h_b),
+      static_cast<Tout *>(h_c), B, M, N, K, ccglib::mma::row_major);
+}
+
+} // namespace ccglib::test


### PR DESCRIPTION
The new `Pipeline` class runs all steps (packing/transpose/gemm) as needed depending on the inputs.

A test for `float16 -> float32` was added.
Before merging, a `int1 -> int32` should be added as well to verify the packing kernel works as expected in the pipeline.