### PR TITLE
Fix compilation of benchmark in HIP mode when host compiler != hipcc

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -27,6 +27,10 @@ foreach(benchmark ${BENCHMARKS})
     target_link_libraries(${TARGET} pmt)
   endif()
 
+  if(${CCGLIB_BACKEND_HIP})
+    set_source_files_properties(${SOURCE} PROPERTIES LANGUAGE HIP)
+  endif()
+
   target_include_directories(${TARGET} PRIVATE "${PROJECT_SOURCE_DIR}/include")
 
 endforeach()


### PR DESCRIPTION
As per title, when the source language is not explicitly set to HIP, the `__HIP__` macro is not defined and ccglib/cudawrappers default to including cuda files.