### PR TITLE
Add support for bfloat16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,7 @@ include(FetchContent)
 FetchContent_Declare(
   cudawrappers
   GIT_REPOSITORY https://github.com/nlesc-recruit/cudawrappers
-  # temporary until source embedding + header inlining is fixed in cudawrappers
-  GIT_TAG "527211f2abbe6ca2f245461074b90124c71f08e4")
-# GIT_TAG "main")
+  GIT_TAG "main")
 FetchContent_MakeAvailable(cudawrappers)
 
 include(cmake/xtensor.cmake)

--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ ccglib supports a range of input/output data types, depending on the available h
 
 Input type  | Output type      | NVIDIA | AMD | Notes
 ----------  | -----------      | ------ | - | -
-float16     | float32/float16\* | ✅              | ✅ | -
-float32     | float32/float16\* | ❌              | CDNA only  | | -
+bfloat16    | bfloat16/float32 | float32 output only             | ✅ | -
+float16     | float32/float16  | ✅              | ✅ | -
+float32     | float32/bfloat16/float16\* | ❌              | CDNA only  | | -
 tensorfloat | float32/float16\* | Ampere or newer | ❌ | Input data must be in float32 format, conversion to tensorfloat is automatic
 int1        | int32            | ✅              | ❌ | Input bits must be packed into int32 values. ccglib provides a tool to do this
 
-\* float16 output is native float32 output downcasted to float16.
+\* bfloat16/float16 output is native float32 output downcasted to bfloat16/float16.
 
 
 With matrix-matrix multiplication defined as `C = A x B`, ccglib requires the A matrix to be in row-major format and the B matrix to be in column-major format. The C matrix can be either row-major or column-major.

--- a/include/ccglib/bf16.h
+++ b/include/ccglib/bf16.h
@@ -1,0 +1,17 @@
+#if defined(__HIP__)
+// rocWMMA uses hip_bfloat16, defined in hip_bfloat16.h. HIP uses
+// __hip_bfloat16, defined in hip_bf16.h, in e.g. type cast operators. There is
+// no type cast between hip_bfloat16 and __hip_bfloat16, so we resort to using
+// a different type on the host and device, assuming the underlying data is
+// identical.
+#ifdef __HIP_DEVICE_COMPILE__
+#include <hip/hip_bfloat16.h>
+using bf16 = hip_bfloat16;
+#else
+#include <hip/hip_bf16.h>
+using bf16 = __hip_bfloat16;
+#endif
+#else
+#include <cuda_bf16.h>
+using bf16 = __nv_bfloat16;
+#endif

--- a/include/ccglib/common/value_type.h
+++ b/include/ccglib/common/value_type.h
@@ -11,18 +11,18 @@
 
 namespace ccglib {
 
-enum ValueType { int1, int32, float16, float32 };
+enum ValueType { int1, int32, bfloat16, float16, float32 };
 
 constexpr size_t __host__ __device__ CalculateBitWidth(ValueType type) {
   switch (type) {
   case ValueType::int1:
     return 1;
-  case ValueType::int32:
-    return CHAR_BIT * sizeof(unsigned);
+  case ValueType::bfloat16:
   case ValueType::float16:
-    return CHAR_BIT * sizeof(half);
+    return 16;
   case ValueType::float32:
-    return CHAR_BIT * sizeof(float);
+  case ValueType::int32:
+    return 32;
   default:
     // Default case, shouldn't happen
     return 0;

--- a/include/ccglib/gemm/reference.h
+++ b/include/ccglib/gemm/reference.h
@@ -1,6 +1,7 @@
 #ifndef REFERENCE_GEMM_H_
 #define REFERENCE_GEMM_H_
 
+#include <ccglib/bf16.h>
 #include <ccglib/fp16.h>
 #include <ccglib/gemm/mem_order.h>
 
@@ -15,6 +16,15 @@ public:
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
   virtual void
   Run(const float *a, const float *b, half *c, size_t M, size_t N, size_t K,
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+  virtual void
+  Run(const bf16 *a, const bf16 *b, bf16 *c, size_t M, size_t N, size_t K,
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+  virtual void
+  Run(const bf16 *a, const bf16 *b, float *c, size_t M, size_t N, size_t K,
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+  virtual void
+  Run(const float *a, const float *b, bf16 *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
   virtual void
   Run(const float *a, const float *b, float *c, size_t M, size_t N, size_t K,

--- a/kernels/gemm_kernel_float.cu
+++ b/kernels/gemm_kernel_float.cu
@@ -10,6 +10,7 @@ namespace wmma = rocwmma;
 using namespace nvcuda;
 #endif
 
+#include "ccglib/bf16.h"
 #include "ccglib/fp16.h"
 
 // clang-format off

--- a/kernels/type_selector.h
+++ b/kernels/type_selector.h
@@ -11,6 +11,9 @@ namespace wmma = rocwmma;
 using namespace nvcuda;
 #endif
 
+#include "ccglib/bf16.h"
+#include "ccglib/fp16.h"
+
 #include "value_type.h"
 using ccglib::ValueType;
 

--- a/kernels/type_selector.h
+++ b/kernels/type_selector.h
@@ -80,6 +80,28 @@ template <> struct TypeSelector<ValueType::int1, ValueType::int32> {
   static constexpr bool IS_DOWNCAST_OP = false;
 };
 
+template <> struct TypeSelector<ValueType::bfloat16, ValueType::bfloat16> {
+  using Tin = bf16;
+  using Ttc = bf16;
+  using Tshared = bf16;
+  using Tout = bf16;
+
+  static constexpr unsigned PACKING_FACTOR = 1;
+  static constexpr size_t OVERRIDE_K_PER_WMMA = 0;
+  static constexpr bool IS_DOWNCAST_OP = false;
+};
+
+template <> struct TypeSelector<ValueType::bfloat16, ValueType::float32> {
+  using Tin = bf16;
+  using Ttc = bf16;
+  using Tshared = float;
+  using Tout = float;
+
+  static constexpr unsigned PACKING_FACTOR = 1;
+  static constexpr size_t OVERRIDE_K_PER_WMMA = 0;
+  static constexpr bool IS_DOWNCAST_OP = false;
+};
+
 template <> struct TypeSelector<ValueType::float16, ValueType::float16> {
   using Tin = half;
   using Ttc = half;
@@ -117,6 +139,21 @@ template <> struct TypeSelector<ValueType::float32, ValueType::float32> {
   static constexpr unsigned PACKING_FACTOR = 1;
   static constexpr size_t OVERRIDE_K_PER_WMMA = 0;
   static constexpr bool IS_DOWNCAST_OP = false;
+};
+
+template <> struct TypeSelector<ValueType::float32, ValueType::bfloat16> {
+  using Tin = float;
+#ifdef __HIP_PLATFORM_AMD__
+  using Ttc = float;
+#else
+  using Ttc = wmma::precision::tf32;
+#endif
+  using Tshared = float;
+  using Tout = bf16;
+
+  static constexpr unsigned PACKING_FACTOR = 1;
+  static constexpr size_t OVERRIDE_K_PER_WMMA = 8;
+  static constexpr bool IS_DOWNCAST_OP = true;
 };
 
 template <> struct TypeSelector<ValueType::float32, ValueType::float16> {

--- a/src/mma/CMakeLists.txt
+++ b/src/mma/CMakeLists.txt
@@ -1,7 +1,8 @@
 project(gemm-mma)
 
-add_library(${PROJECT_NAME} OBJECT GEMM.cpp Kernel.cpp KernelFloat16.cpp
-                                   KernelFloat32.cpp KernelInt1.cpp)
+add_library(
+  ${PROJECT_NAME} OBJECT GEMM.cpp Kernel.cpp KernelFloat16.cpp
+                         KernelBfloat16.cpp KernelFloat32.cpp KernelInt1.cpp)
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${CCGLIB_INCLUDE_DIR})
 

--- a/src/mma/Kernel.cpp
+++ b/src/mma/Kernel.cpp
@@ -20,6 +20,9 @@ void Kernel::SetParameters(Precision precision) {
   case ValueType::float16:
     parameters_ = Kernel::GetCompileParameters<ValueType::float16>();
     break;
+  case ValueType::bfloat16:
+    parameters_ = Kernel::GetCompileParameters<ValueType::bfloat16>();
+    break;
   case ValueType::float32:
     parameters_ = Kernel::GetCompileParameters<ValueType::float32>();
     break;
@@ -37,6 +40,8 @@ std::string Kernel::GetSource() const {
   switch (precision_.input_type) {
   case ValueType::float16:
     return Kernel::GetSource<ValueType::float16>();
+  case ValueType::bfloat16:
+    return Kernel::GetSource<ValueType::bfloat16>();
   case ValueType::float32:
     return Kernel::GetSource<ValueType::float32>();
   case ValueType::int1:

--- a/src/mma/KernelBfloat16.cpp
+++ b/src/mma/KernelBfloat16.cpp
@@ -1,0 +1,38 @@
+#include <string>
+
+#include "Kernel.h"
+
+extern const char _binary_kernels_gemm_kernel_float_cu_start,
+    _binary_kernels_gemm_kernel_float_cu_end;
+
+namespace ccglib::mma {
+
+template <>
+Kernel::Parameters Kernel::GetCompileParameters<ValueType::bfloat16>() const {
+  // The preprocessor statements below force clang-format to use abnormal
+  // format. To be consistent with the rest of the code, it is temporarily
+  // disabled.
+  // clang-format off
+  return Kernel::Parameters{.m_per_block = 128,
+                            .m_per_warp = 128,
+                            .m_per_wmma = 16,
+
+                            .n_per_block = 64,
+                            .n_per_warp = 16,
+                            .n_per_wmma = 16,
+                            
+                            .k_per_wmma = 16,
+#if defined(__HIP_PLATFORM_AMD__)
+    .nbuffer = 1
+#else
+    .nbuffer = 4
+#endif
+  };
+  // clang-format on
+}
+
+template <> std::string Kernel::GetSource<ValueType::bfloat16>() const {
+  return std::string(&_binary_kernels_gemm_kernel_float_cu_start,
+                     &_binary_kernels_gemm_kernel_float_cu_end);
+}
+} // namespace ccglib::mma

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -15,8 +15,9 @@ namespace {
 template <typename Tin, typename Tout>
 void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
          ccglib::mma::MemOrder output_mem_order) {
-  // Use the output type as compute type, unless the output is a narrow type
-  // because tensor core multiply-add still happens in the wider type
+  // Use float as the compute type when Tout is half or bf16 because tensor core
+  // multiply-add operations execute in float precision. Otherwise, preserve
+  // Tout.
   using ComputeType =
       typename std::conditional<std::is_same<Tout, half>::value ||
                                     std::is_same<Tout, bf16>::value,

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -16,21 +16,12 @@ template <typename Tin, typename Tout>
 void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
          ccglib::mma::MemOrder output_mem_order) {
 
-// FIXME: When using 'half' output type on an AMD GPU, the computation cannot be
-// done using 'half' type. This is because the required operators, `__half&
-// operator+(const __half& x)` and `__half& operator*(const __half& x)`, are
-// missing. According to the HIP documentation, they should be available. A bug
-// report has been submitted: https://github.com/ROCm/HIP/issues/3690 but the
-// fix has not yet been upstreamed.
-#if defined(__HIP_PLATFORM_AMD__)
+  // Use the output type as compute type, unless the output is a narrow type
+  // because tensor core multiply-add still happens in the wider type
   using ComputeType =
-      typename std::conditional<std::is_same<Tin, half>::value ||
-                                    std::is_same<Tout, half>::value,
+      typename std::conditional<std::is_same<Tout, half>::value ||
+                                    std::is_same<Tout, bf16>::value,
                                 float, Tout>::type;
-#else
-  using ComputeType = Tout;
-#endif
-
   const std::array<size_t, 3> a_shape = {2, M, K};
   const std::array<size_t, 3> b_shape = {2, N, K};
   std::array<size_t, 3> c_shape;
@@ -51,14 +42,14 @@ void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
 #pragma omp parallel for collapse(2)
   for (size_t m = 0; m < M; ++m) {
     for (size_t n = 0; n < N; ++n) {
-      ComputeType sum_real = 0;
-      ComputeType sum_imag = 0;
+      ComputeType sum_real{0};
+      ComputeType sum_imag{0};
 
       for (size_t k = 0; k < K; ++k) {
-        const ComputeType a_real = a_view(0, m, k);
-        const ComputeType a_imag = a_view(1, m, k);
-        const ComputeType b_real = b_view(0, n, k);
-        const ComputeType b_imag = b_view(1, n, k);
+        const ComputeType a_real = static_cast<ComputeType>(a_view(0, m, k));
+        const ComputeType a_imag = static_cast<ComputeType>(a_view(1, m, k));
+        const ComputeType b_real = static_cast<ComputeType>(b_view(0, n, k));
+        const ComputeType b_imag = static_cast<ComputeType>(b_view(1, n, k));
 
         ComputeType term_real = a_real * b_real - a_imag * b_imag;
         ComputeType term_imag = a_real * b_imag + a_imag * b_real;
@@ -210,6 +201,21 @@ void GEMM::Run(const half *a, const half *b, float *c, size_t M, size_t N,
 void GEMM::Run(const float *a, const float *b, half *c, size_t M, size_t N,
                size_t K, ccglib::mma::MemOrder output_mem_order) {
   ::Run<float, half>(a, b, c, M, N, K, output_mem_order);
+}
+
+void GEMM::Run(const bf16 *a, const bf16 *b, bf16 *c, size_t M, size_t N,
+               size_t K, ccglib::mma::MemOrder output_mem_order) {
+  ::Run<bf16, bf16>(a, b, c, M, N, K, output_mem_order);
+}
+
+void GEMM::Run(const bf16 *a, const bf16 *b, float *c, size_t M, size_t N,
+               size_t K, ccglib::mma::MemOrder output_mem_order) {
+  ::Run<bf16, float>(a, b, c, M, N, K, output_mem_order);
+}
+
+void GEMM::Run(const float *a, const float *b, bf16 *c, size_t M, size_t N,
+               size_t K, ccglib::mma::MemOrder output_mem_order) {
+  ::Run<float, bf16>(a, b, c, M, N, K, output_mem_order);
 }
 
 void GEMM::Run(const float *a, const float *b, float *c, size_t M, size_t N,

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -15,7 +15,6 @@ namespace {
 template <typename Tin, typename Tout>
 void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
          ccglib::mma::MemOrder output_mem_order) {
-
   // Use the output type as compute type, unless the output is a narrow type
   // because tensor core multiply-add still happens in the wider type
   using ComputeType =

--- a/test/gemm/fpequals.h
+++ b/test/gemm/fpequals.h
@@ -21,8 +21,6 @@ template <typename T> constexpr float getEpsilon() {
   } else if constexpr (std::is_same_v<T, bf16>) {
     // bfloat16 uses an 8-bit mantissa (of which 7 bits are stored)
     // the precision for normal numbers is therefore 2^-7
-    // Note: this epsilon exists already in e.g. HIP, but is not constexpr so
-    // cannot be reused here
     return 0.0078125;
   }
   return std::numeric_limits<T>::epsilon();

--- a/test/gemm/fpequals.h
+++ b/test/gemm/fpequals.h
@@ -15,7 +15,7 @@ template <typename T> constexpr float getEpsilon() {
   if constexpr (std::is_same_v<T, __half> || std::is_same_v<T, float>) {
     // float16 uses an 11-bit mantissa (of which 10 bits are stored)
     // within the kernel, float32 is converted to tf32
-    // tf32 uses the same mantissa as the half-precision math
+    // fp16 and tf32 use an 10-bit mantissa
     // the precision for normal numbers is therefore 2^-10
     return 0.000976562;
   } else if constexpr (std::is_same_v<T, bf16>) {

--- a/test/gemm/fpequals.h
+++ b/test/gemm/fpequals.h
@@ -42,7 +42,7 @@ template <typename T> void fpEquals(T x, T y) {
   const double numerator = std::fabs(x_conv - y_conv);
   const double divisor = std::fabs(x_conv) + std::fabs(y_conv) + 1.0;
   const double rel_error = numerator / divisor;
-  REQUIRE(rel_error < max_rel_error);
+  REQUIRE(rel_error <= max_rel_error);
 }
 
 template <typename T> void fpEquals(std::complex<T> x, std::complex<T> y) {

--- a/test/gemm/fpequals.h
+++ b/test/gemm/fpequals.h
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <limits>
 
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <ccglib/bf16.h>
 #include <ccglib/fp16.h>
 
@@ -28,28 +28,26 @@ template <typename T> constexpr float getEpsilon() {
   return std::numeric_limits<T>::epsilon();
 }
 
-template <typename T> void fpEquals(T x, T y, size_t K = 1) {
-  constexpr float epsilon = getEpsilon<T>();
+template <typename T> void fpEquals(T x, T y) {
+  // Follow the same approach as rocWMMA: the max relative error should be
+  // < 10 * epsilon. If the output is a narrow type, the downcast results in a
+  // loss of precision and the tolerance is increased to 100 * epsilon.
+  constexpr double epsilon = static_cast<double>(getEpsilon<T>());
+  constexpr double max_rel_error =
+      (sizeof(T) < sizeof(float32) ? 100 : 10) * epsilon;
 
-  if constexpr (std::is_same_v<T, bf16> || std::is_same_v<T, half>) {
-    // We need to upcast since Catch2 cannot print bfloat16/half types in case
-    // of test failure.
-    const float x_conv = static_cast<float>(x);
-    const float y_conv = static_cast<float>(y);
+  const double x_conv = static_cast<double>(x);
+  const double y_conv = static_cast<double>(y);
 
-    // We are more lenient in WithinAbs since we use a less precise type.
-    REQUIRE_THAT(y_conv, Catch::Matchers::WithinAbs(x_conv, epsilon * K) ||
-                             Catch::Matchers::WithinRel(x_conv, epsilon * 100));
-  } else {
-    REQUIRE_THAT(y, Catch::Matchers::WithinAbs(x, epsilon * K) ||
-                        Catch::Matchers::WithinRel(x, epsilon * 100));
-  }
+  const double numerator = std::fabs(x_conv - y_conv);
+  const double divisor = std::fabs(x_conv) + std::fabs(y_conv) + 1.0;
+  const double rel_error = numerator / divisor;
+  REQUIRE(rel_error < max_rel_error);
 }
 
-template <typename T>
-void fpEquals(std::complex<T> x, std::complex<T> y, size_t K = 1) {
-  fpEquals(x.real(), y.real(), K);
-  fpEquals(x.imag(), y.imag(), K);
+template <typename T> void fpEquals(std::complex<T> x, std::complex<T> y) {
+  fpEquals(x.real(), y.real());
+  fpEquals(x.imag(), y.imag());
 }
 
 } // namespace ccglib::test

--- a/test/gemm/fpequals.h
+++ b/test/gemm/fpequals.h
@@ -31,26 +31,17 @@ template <typename T> constexpr float getEpsilon() {
 template <typename T> void fpEquals(T x, T y, size_t K = 1) {
   constexpr float epsilon = getEpsilon<T>();
 
-  if constexpr (std::is_same_v<T, bf16>) {
-    // We need to upcast since Catch2 cannot print bfloat16 types in case of
-    // test failure.
+  if constexpr (std::is_same_v<T, bf16> || std::is_same_v<T, half>) {
+    // We need to upcast since Catch2 cannot print bfloat16/half types in case
+    // of test failure.
     const float x_conv = static_cast<float>(x);
     const float y_conv = static_cast<float>(y);
 
     // We are more lenient in WithinAbs since we use a less precise type.
     REQUIRE_THAT(y_conv, Catch::Matchers::WithinAbs(x_conv, epsilon * K) ||
                              Catch::Matchers::WithinRel(x_conv, epsilon * 100));
-  } else if constexpr (std::is_same_v<T, half>) {
-    // We need to upcast since Catch2 cannot print float16/half types in case of
-    // test failure.
-    const float x_conv = __half2float(x);
-    const float y_conv = __half2float(y);
-
-    // We are more lenient in WithinAbs since we use a less precise type.
-    REQUIRE_THAT(y_conv, Catch::Matchers::WithinAbs(x_conv, epsilon * K) ||
-                             Catch::Matchers::WithinRel(x_conv, epsilon * 100));
   } else {
-    REQUIRE_THAT(y, Catch::Matchers::WithinAbs(x, epsilon) ||
+    REQUIRE_THAT(y, Catch::Matchers::WithinAbs(x, epsilon * K) ||
                         Catch::Matchers::WithinRel(x, epsilon * 100));
   }
 }

--- a/test/gemm/fpequals.h
+++ b/test/gemm/fpequals.h
@@ -6,6 +6,7 @@
 #include <limits>
 
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <ccglib/bf16.h>
 #include <ccglib/fp16.h>
 
 namespace ccglib::test {
@@ -17,6 +18,12 @@ template <typename T> constexpr float getEpsilon() {
     // tf32 uses the same mantissa as the half-precision math
     // the precision for normal numbers is therefore 2^-10
     return 0.000976562;
+  } else if constexpr (std::is_same_v<T, bf16>) {
+    // bfloat16 uses an 8-bit mantissa (of which 7 bits are stored)
+    // the precision for normal numbers is therefore 2^-7
+    // Note: this epsilon exists already in e.g. HIP, but is not constexpr so
+    // cannot be reused here
+    return 0.0078125;
   }
   return std::numeric_limits<T>::epsilon();
 }
@@ -24,7 +31,16 @@ template <typename T> constexpr float getEpsilon() {
 template <typename T> void fpEquals(T x, T y, size_t K = 1) {
   constexpr float epsilon = getEpsilon<T>();
 
-  if constexpr (std::is_same_v<T, half>) {
+  if constexpr (std::is_same_v<T, bf16>) {
+    // We need to upcast since Catch2 cannot print bfloat16 types in case of
+    // test failure.
+    const float x_conv = static_cast<float>(x);
+    const float y_conv = static_cast<float>(y);
+
+    // We are more lenient in WithinAbs since we use a less precise type.
+    REQUIRE_THAT(y_conv, Catch::Matchers::WithinAbs(x_conv, epsilon * K) ||
+                             Catch::Matchers::WithinRel(x_conv, epsilon * 100));
+  } else if constexpr (std::is_same_v<T, half>) {
     // We need to upcast since Catch2 cannot print float16/half types in case of
     // test failure.
     const float x_conv = __half2float(x);

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -4,8 +4,8 @@
 #include <cudawrappers/cu.hpp>
 #include <cudawrappers/nvrtc.hpp>
 
-#include <ccglib/common/arch.h>
 #include <ccglib/bf16.h>
+#include <ccglib/common/arch.h>
 #include <ccglib/common/helper.h>
 #include <ccglib/common/precision.h>
 #include <ccglib/fp16.h>

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -5,6 +5,7 @@
 #include <cudawrappers/nvrtc.hpp>
 
 #include <ccglib/common/arch.h>
+#include <ccglib/bf16.h>
 #include <ccglib/common/helper.h>
 #include <ccglib/common/precision.h>
 #include <ccglib/fp16.h>
@@ -21,6 +22,7 @@
 #include <xtensor/xtensor.hpp>
 
 #include "verify.h"
+
 #ifndef COMPLEX
 #define COMPLEX 2
 #endif
@@ -33,6 +35,23 @@ static inline float float_to_tf32(float x) {
   return *reinterpret_cast<float *>(value_int);
 }
 
+static inline std::string type_to_string(ccglib::ValueType type) {
+  switch (type) {
+  case ccglib::int1:
+    return "int1";
+  case ccglib::int32:
+    return "int32";
+  case ccglib::bfloat16:
+    return "bfloat16";
+  case ccglib::float16:
+    return "float16";
+  case ccglib::float32:
+    return "float32";
+  default:
+    return "unrecognized type";
+  }
+}
+
 namespace ccglib::test {
 
 template <typename Tin, typename Tout, ccglib::ValueType InputPrecision,
@@ -41,6 +60,8 @@ class ComplexGemmTestFixture {
 public:
   using InputType = Tin;
   using OutputType = Tout;
+  const std::string InputTypeName = type_to_string(InputPrecision);
+  const std::string OutputTypeName = type_to_string(OutputPrecision);
   std::unique_ptr<cu::Device> device_;
 
   ComplexGemmTestFixture() {
@@ -126,6 +147,16 @@ private:
       for (int idx = 0; idx < bytes_b_ / sizeof(T); idx++) {
         b[idx] = __float2half(static_cast<float>(rand_r(&seed)) /
                               static_cast<float>(RAND_MAX));
+      }
+    } else if constexpr (std::is_same_v<T, bf16>) {
+      unsigned int seed = 0;
+      for (int idx = 0; idx < bytes_a_ / sizeof(T); idx++) {
+        a[idx] = static_cast<bf16>(static_cast<float>(rand_r(&seed)) /
+                                   static_cast<float>(RAND_MAX));
+      }
+      for (int idx = 0; idx < bytes_b_ / sizeof(T); idx++) {
+        b[idx] = static_cast<bf16>(static_cast<float>(rand_r(&seed)) /
+                                   static_cast<float>(RAND_MAX));
       }
     } else if constexpr (std::is_same_v<T, float>) {
       unsigned int seed = 0;
@@ -293,7 +324,13 @@ public:
 };
 
 using TestTypesComplexGemm =
-    std::tuple<ComplexGemmTestFixture<half, half, ccglib::ValueType::float16,
+    std::tuple<ComplexGemmTestFixture<bf16, bf16, ccglib::ValueType::bfloat16,
+                                      ccglib::ValueType::bfloat16>,
+               ComplexGemmTestFixture<float, bf16, ccglib::ValueType::float32,
+                                      ccglib::ValueType::bfloat16>,
+               ComplexGemmTestFixture<bf16, float, ccglib::ValueType::bfloat16,
+                                      ccglib::ValueType::float32>,
+               ComplexGemmTestFixture<half, half, ccglib::ValueType::float16,
                                       ccglib::ValueType::float16>,
                ComplexGemmTestFixture<float, half, ccglib::ValueType::float32,
                                       ccglib::ValueType::float16>,
@@ -374,9 +411,8 @@ template <typename Fixture> struct GemmTestBasic : public Fixture {
   void run_tests() {
     using Traits = GemmTestTraits<Fixture>;
 
-    SECTION(
-        "basic-row-major - InputSize: " + std::to_string(Traits::InputSize) +
-        "b, OutputSize: " + std::to_string(Traits::OutputSize) + "b") {
+    SECTION("basic-row-major - InputType: " + this->InputTypeName +
+            ", OutputType: " + this->OutputTypeName) {
       this->init(Traits::M_row_major.aligned, Traits::N_row_major.aligned,
                  Traits::K_row_major.aligned);
       this->complex_gemm_basic(ccglib::mma::row_major);
@@ -385,9 +421,8 @@ template <typename Fixture> struct GemmTestBasic : public Fixture {
                  Traits::K_row_major.unaligned);
       this->complex_gemm_basic(ccglib::mma::row_major);
     }
-    SECTION(
-        "basic-col-major - InputSize: " + std::to_string(Traits::InputSize) +
-        "b. OutputSize: " + std::to_string(Traits::OutputSize) + "b") {
+    SECTION("basic-col-major - InputType: " + this->InputTypeName +
+            ", OutputType: " + this->OutputTypeName) {
       this->init(Traits::M_col_major.aligned, Traits::N_col_major.aligned,
                  Traits::K_col_major.aligned);
       this->complex_gemm_basic(ccglib::mma::col_major);
@@ -403,8 +438,8 @@ template <typename Fixture> struct GemmTestOpt : public Fixture {
   void run_tests() {
     using Traits = GemmTestTraits<Fixture>;
 
-    SECTION("opt-row-major - InputSize: " + std::to_string(Traits::InputSize) +
-            "b, OutputSize: " + std::to_string(Traits::OutputSize) + "b") {
+    SECTION("opt-row-major - InputType: " + this->InputTypeName +
+            ", OutputType: " + this->OutputTypeName) {
       this->init(Traits::M_row_major.aligned, Traits::N_row_major.aligned,
                  Traits::K_row_major.aligned);
       this->complex_gemm_opt(ccglib::mma::row_major);
@@ -413,8 +448,8 @@ template <typename Fixture> struct GemmTestOpt : public Fixture {
                  Traits::K_row_major.unaligned);
       this->complex_gemm_basic(ccglib::mma::row_major);
     }
-    SECTION("opt-col-major - InputSize: " + std::to_string(Traits::InputSize) +
-            "b, OutputSize: " + std::to_string(Traits::OutputSize) + "b") {
+    SECTION("opt-col-major - InputType: " + this->InputTypeName +
+            ", OutputType: " + this->OutputTypeName) {
       this->init(Traits::M_col_major.aligned, Traits::N_col_major.aligned,
                  Traits::K_col_major.aligned);
       this->complex_gemm_opt(ccglib::mma::col_major);
@@ -424,9 +459,8 @@ template <typename Fixture> struct GemmTestOpt : public Fixture {
       this->complex_gemm_opt(ccglib::mma::col_major);
     }
 
-    SECTION("opt-row-major-complex-interleaved - InputSize: " +
-            std::to_string(Traits::InputSize) +
-            "b, OutputSize: " + std::to_string(Traits::OutputSize) + "b") {
+    SECTION("opt-row-major-complex-interleaved - InputType: " +
+            this->InputTypeName + ", OutputType: " + this->OutputTypeName) {
       this->init(Traits::M_row_major.aligned, Traits::N_row_major.aligned,
                  Traits::K_row_major.aligned);
       this->complex_gemm_opt(ccglib::mma::row_major,
@@ -438,9 +472,8 @@ template <typename Fixture> struct GemmTestOpt : public Fixture {
                              ccglib::complex_interleaved);
     }
 
-    SECTION("opt-col-major-complex-interleaved - InputSize: " +
-            std::to_string(Traits::InputSize) +
-            "b, OutputSize: " + std::to_string(Traits::OutputSize) + "b") {
+    SECTION("opt-col-major-complex-interleaved - InputType: " +
+            this->InputTypeName + ", OutputType: " + this->OutputTypeName) {
       this->init(Traits::M_col_major.aligned, Traits::N_col_major.aligned,
                  Traits::K_col_major.aligned);
       this->complex_gemm_opt(ccglib::mma::col_major,

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -323,21 +323,24 @@ public:
   }
 };
 
-using TestTypesComplexGemm =
-    std::tuple<ComplexGemmTestFixture<bf16, bf16, ccglib::ValueType::bfloat16,
-                                      ccglib::ValueType::bfloat16>,
-               ComplexGemmTestFixture<float, bf16, ccglib::ValueType::float32,
-                                      ccglib::ValueType::bfloat16>,
-               ComplexGemmTestFixture<bf16, float, ccglib::ValueType::bfloat16,
-                                      ccglib::ValueType::float32>,
-               ComplexGemmTestFixture<half, half, ccglib::ValueType::float16,
-                                      ccglib::ValueType::float16>,
-               ComplexGemmTestFixture<float, half, ccglib::ValueType::float32,
-                                      ccglib::ValueType::float16>,
-               ComplexGemmTestFixture<half, float, ccglib::ValueType::float16,
-                                      ccglib::ValueType::float32>,
-               ComplexGemmTestFixture<float, float, ccglib::ValueType::float32,
-                                      ccglib::ValueType::float32>>;
+using TestTypesComplexGemm = std::tuple<
+// CUDA does not support bfloat16 as accumulation type
+#ifdef __HIP_PLATFORM_AMD__
+    ComplexGemmTestFixture<bf16, bf16, ccglib::ValueType::bfloat16,
+                           ccglib::ValueType::bfloat16>,
+#endif
+    ComplexGemmTestFixture<float, bf16, ccglib::ValueType::float32,
+                           ccglib::ValueType::bfloat16>,
+    ComplexGemmTestFixture<bf16, float, ccglib::ValueType::bfloat16,
+                           ccglib::ValueType::float32>,
+    ComplexGemmTestFixture<half, half, ccglib::ValueType::float16,
+                           ccglib::ValueType::float16>,
+    ComplexGemmTestFixture<float, half, ccglib::ValueType::float32,
+                           ccglib::ValueType::float16>,
+    ComplexGemmTestFixture<half, float, ccglib::ValueType::float16,
+                           ccglib::ValueType::float32>,
+    ComplexGemmTestFixture<float, float, ccglib::ValueType::float32,
+                           ccglib::ValueType::float32>>;
 
 // GemmTestTraits is a template struct that provides parameters for the
 // GemmTestBasic and GemmTestOpt test cases.

--- a/test/gemm/reference.cpp
+++ b/test/gemm/reference.cpp
@@ -6,6 +6,7 @@
 #include <xtensor/xtensor.hpp>
 #include <xtensor/xview.hpp>
 
+#include <ccglib/bf16.h>
 #include <ccglib/common/helper.h>
 #include <ccglib/fp16.h>
 #include <ccglib/gemm/reference.h>
@@ -20,10 +21,20 @@ public:
     const size_t K = 2;
     const size_t COMPLEX = 2;
     // Matrix a row-major a(2,M,K)
-    const InputType a[COMPLEX * M * K] = {1., 2., 3., 4., 5., 6.,
-                                          6., 5., 4., 3., 2., 1.};
-    // Matrix a column-major a(2,M,K)
-    const InputType b[COMPLEX * N * K] = {1., 2., 3., 4., 4., 3., 2., 1.};
+    // the static_casts are necessary for handling the bfloat16 type
+    const InputType a[COMPLEX * M * K] = {
+        static_cast<InputType>(1), static_cast<InputType>(2),
+        static_cast<InputType>(3), static_cast<InputType>(4),
+        static_cast<InputType>(5), static_cast<InputType>(6),
+        static_cast<InputType>(6), static_cast<InputType>(5),
+        static_cast<InputType>(4), static_cast<InputType>(3),
+        static_cast<InputType>(2), static_cast<InputType>(1)};
+    // Matrix b column-major b(2,N,K)
+    const InputType b[COMPLEX * N * K] = {
+        static_cast<InputType>(1), static_cast<InputType>(2),
+        static_cast<InputType>(3), static_cast<InputType>(4),
+        static_cast<InputType>(4), static_cast<InputType>(3),
+        static_cast<InputType>(2), static_cast<InputType>(1)};
     // Matrix c=a*b row-major c(2,M,N)
     const std::array<float, COMPLEX * M * N> c_ref_row_major = {
         -34, -6, -14, 14, 6, 34, 26, 42, 34, 34, 42, 26};
@@ -42,7 +53,7 @@ public:
   }
 };
 
-using TestTypes = std::tuple<half, float>;
+using TestTypes = std::tuple<half, bf16, float>;
 TEMPLATE_LIST_TEST_CASE_METHOD(TestImpl, "Reference complex float",
                                "[correctness]", TestTypes) {
   SECTION("Simple reference output") { TestImpl<TestType>::runTestReference(); }

--- a/test/gemm/verify.h
+++ b/test/gemm/verify.h
@@ -58,7 +58,7 @@ void verify(const Tin *a, const Tin *b, const Tout *c, size_t B, size_t M,
           ref = {c_ref(b, 0, n, m), c_ref(b, 1, n, m)};
           tst = {c_view(b, 0, n, m), c_view(b, 1, n, m)};
         }
-        ccglib::test::fpEquals(ref, tst, K);
+        ccglib::test::fpEquals(ref, tst);
       }
     }
   }

--- a/test/transpose/transpose.cpp
+++ b/test/transpose/transpose.cpp
@@ -6,6 +6,7 @@
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xtensor.hpp>
 
+#include <ccglib/bf16.h>
 #include <ccglib/common/precision.h>
 #include <ccglib/fp16.h>
 #include <ccglib/transpose/transpose.h>
@@ -154,6 +155,8 @@ public:
 
 using TransposeTestFixtureFloat16 =
     TransposeTestFixture<half, ccglib::ValueType::float16>;
+using TransposeTestFixtureBfloat16 =
+    TransposeTestFixture<bf16, ccglib::ValueType::bfloat16>;
 using TransposeTestFixtureInt1 =
     TransposeTestFixture<unsigned int, ccglib::ValueType::int1>;
 
@@ -165,6 +168,18 @@ TEST_CASE_METHOD(TransposeTestFixtureFloat16, "Transpose Test - float16",
   }
   SECTION("complex-interleaved") {
     TransposeTestFixtureFloat16::transpose(
+        ccglib::ComplexAxisLocation::complex_interleaved);
+  }
+}
+
+TEST_CASE_METHOD(TransposeTestFixtureBfloat16, "Transpose Test - bfloat16",
+                 "[transpose-test-bfloat16]") {
+  SECTION("complex-middle") {
+    TransposeTestFixtureBfloat16::transpose(
+        ccglib::ComplexAxisLocation::complex_planar);
+  }
+  SECTION("complex-last") {
+    TransposeTestFixtureBfloat16::transpose(
         ccglib::ComplexAxisLocation::complex_interleaved);
   }
 }


### PR DESCRIPTION
This PR adds bfloat16, which follows mostly the same code path as float16. All type combinations supported by float16 are supported by bfloat16 as well:
- bfloat16 to bfloat16
- bfloat16 to float32
- float32 to bfloat16

I've also changed the tests to print the type name instead of number of bits.

Not all testes pass yet, I'm not sure if this is a real problem with the kernel or instead with how we calculate the tolerances in the test.

UPDATE: the tests pass after reimplementing `fpEquals` using the same approach as rocWMMA.

