### PR TITLE
Guard tf32 for architectures that don't support it

### DIFF
--- a/kernels/type_selector.h
+++ b/kernels/type_selector.h
@@ -148,8 +148,10 @@ template <> struct TypeSelector<ValueType::float32, ValueType::bfloat16> {
   using Tin = float;
 #ifdef __HIP_PLATFORM_AMD__
   using Ttc = float;
-#else
+#elif (__CUDA_ARCH__ >= 800)
   using Ttc = wmma::precision::tf32;
+#else
+  using Ttc = void;
 #endif
   using Tshared = float;
   using Tout = bf16;


### PR DESCRIPTION
`wmma::precision::tf32` is not available on Volta (`sm_70`) and Turing (`sm_75`), so we need to guard its usage in `type_selector.h`.