### PR TITLE
Move direction and complex axis location arguments from packing.Run to constructor

### DIFF
--- a/benchmark/benchmark_packing.cpp
+++ b/benchmark/benchmark_packing.cpp
@@ -127,13 +127,14 @@ int main(int argc, const char *argv[]) {
   }
   for (size_t bench = 0; bench < nr_benchmarks; bench++) {
     for (size_t idx = 0; idx < num_sizes; idx++) {
-      ccglib::packing::Packing packing(N[idx], device, stream);
+      ccglib::packing::Packing packing(N[idx], packing_direction, device,
+                                       stream);
 
       // Run once to get estimate of runtime per kernel
       cu::Event start;
       cu::Event end;
       stream.record(start);
-      packing.Run(d_input, d_output, packing_direction);
+      packing.Run(d_input, d_output);
       stream.record(end);
       stream.synchronize();
       const size_t nr_iterations =
@@ -142,7 +143,7 @@ int main(int argc, const char *argv[]) {
       // If this is the first iteration, do a warmup run
       if (bench == 0 && idx == 0) {
         for (size_t warmup = 0; warmup < nr_iterations; warmup++) {
-          packing.Run(d_input, d_output, packing_direction);
+          packing.Run(d_input, d_output);
         }
       }
       stream.synchronize();
@@ -155,7 +156,7 @@ int main(int argc, const char *argv[]) {
       stream.record(start);
 #endif
       for (size_t iter = 0; iter < nr_iterations; iter++) {
-        packing.Run(d_input, d_output, packing_direction);
+        packing.Run(d_input, d_output);
       }
 #if defined(HAVE_PMT)
       stream.synchronize();

--- a/include/ccglib/packing/packing.h
+++ b/include/ccglib/packing/packing.h
@@ -24,26 +24,25 @@ namespace ccglib::packing {
 
 class Packing {
 public:
-  Packing(size_t N, cu::Device &device, cu::Stream &stream);
+  Packing(size_t N, Direction direction, cu::Device &device, cu::Stream &stream,
+          ComplexAxisLocation input_complex_axis_location =
+              ComplexAxisLocation::complex_planar);
   ~Packing();
-  void Run(cu::HostMemory &h_input, cu::DeviceMemory &d_output,
-           Direction direction,
-           ComplexAxisLocation input_complex_axis_location = complex_planar);
-  void Run(cu::DeviceMemory &d_input, cu::DeviceMemory &d_output,
-           Direction direction,
-           ComplexAxisLocation input_complex_axis_location = complex_planar);
+  void Run(cu::HostMemory &h_input, cu::DeviceMemory &d_output);
+  void Run(cu::DeviceMemory &d_input, cu::DeviceMemory &d_output);
 #ifdef __HIP__
-  Packing(size_t N, hipDevice_t &device, hipStream_t &stream);
-  void Run(unsigned char *h_input, hipDeviceptr_t d_output, Direction direction,
-           ComplexAxisLocation input_complex_axis_location = complex_planar);
-  void Run(hipDeviceptr_t d_input, hipDeviceptr_t d_output, Direction direction,
-           ComplexAxisLocation input_complex_axis_location = complex_planar);
+  Packing(size_t N, Direction direction, hipDevice_t &device,
+          hipStream_t &stream,
+          ComplexAxisLocation input_complex_axis_location =
+              ComplexAxisLocation::complex_planar);
+  void Run(unsigned char *h_input, hipDeviceptr_t d_output);
+  void Run(hipDeviceptr_t d_input, hipDeviceptr_t d_output);
 #else
-  Packing(size_t N, CUdevice &device, CUstream &stream);
-  void Run(unsigned char *h_input, CUdeviceptr d_output, Direction direction,
-           ComplexAxisLocation input_complex_axis_location = complex_planar);
-  void Run(CUdeviceptr d_input, CUdeviceptr d_output, Direction direction,
-           ComplexAxisLocation input_complex_axis_location = complex_planar);
+  Packing(size_t N, Direction direction, CUdevice &device, CUstream &stream,
+          ComplexAxisLocation input_complex_axis_location =
+              ComplexAxisLocation::complex_planar);
+  void Run(unsigned char *h_input, CUdeviceptr d_output);
+  void Run(CUdeviceptr d_input, CUdeviceptr d_output);
 #endif
 
 private:

--- a/kernels/packing_kernel.cu
+++ b/kernels/packing_kernel.cu
@@ -5,22 +5,21 @@
 #endif
 
 extern "C" __global__ void pack_bits(unsigned *output,
-                                     const unsigned char *input,
-                                     bool input_complex_last) {
+                                     const unsigned char *input) {
   size_t tid = threadIdx.x + blockIdx.x * static_cast<size_t>(blockDim.x);
   if (tid >= N) {
     return;
   }
 
   size_t input_index = tid;
-  if (input_complex_last) {
-    // map from real0, real1, .... imag0, imag1... indexing to
-    // real0, imag0, real1, imag1, ...
-    input_index *= 2;
-    if (input_index >= N) {
-      input_index -= N - 1;
-    }
+#ifdef INPUT_COMPLEX_INTERLEAVED
+  // map from real0, real1, .... imag0, imag1... indexing to
+  // real0, imag0, real1, imag1, ...
+  input_index *= 2;
+  if (input_index >= N) {
+    input_index -= N - 1;
   }
+#endif
 
 #if WARP_SIZE == 32
   unsigned output_value = __ballot_sync(__activemask(), input[input_index]);

--- a/test/cuda/packing.cpp
+++ b/test/cuda/packing.cpp
@@ -61,9 +61,9 @@ TEST_CASE("CUDA packing") {
 
   cuda_check(cudaMemcpy(d_in, h_in, bytes_in, cudaMemcpyHostToDevice));
 
-  ccglib::packing::Packing packing(N, device, stream);
+  ccglib::packing::Packing packing(N, ccglib::forward, device, stream);
   packing.Run(reinterpret_cast<CUdeviceptr>(d_in),
-              reinterpret_cast<CUdeviceptr>(d_out), ccglib::forward);
+              reinterpret_cast<CUdeviceptr>(d_out));
 
   cuda_check(cudaMemcpy(h_out, d_out, bytes_out, cudaMemcpyDeviceToHost));
 

--- a/test/hip/packing.cpp
+++ b/test/hip/packing.cpp
@@ -62,9 +62,9 @@ TEST_CASE("HIP packing") {
 
   hip_check(hipMemcpy(d_in, h_in, bytes_in, hipMemcpyHostToDevice));
 
-  ccglib::packing::Packing packing(N, device, stream);
+  ccglib::packing::Packing packing(N, ccglib::forward, device, stream);
   packing.Run(reinterpret_cast<hipDeviceptr_t>(d_in),
-              reinterpret_cast<hipDeviceptr_t>(d_out), ccglib::forward);
+              reinterpret_cast<hipDeviceptr_t>(d_out));
 
   hip_check(hipMemcpy(h_out, d_out, bytes_out, hipMemcpyDeviceToHost));
 

--- a/test/packing/packing.cpp
+++ b/test/packing/packing.cpp
@@ -45,8 +45,8 @@ TEST_CASE("Packing") {
   cu::DeviceMemory d_out(bytes_out);
   d_out.zero(bytes_out);
 
-  ccglib::packing::Packing packing(N, device, stream);
-  packing.Run(d_in, d_out, ccglib::forward);
+  ccglib::packing::Packing packing(N, ccglib::forward, device, stream);
+  packing.Run(d_in, d_out);
 
   // copy output to host
   stream.memcpyDtoHAsync(h_out, d_out, bytes_out);
@@ -89,8 +89,8 @@ TEST_CASE("Unpacking") {
   cu::DeviceMemory d_out(bytes_out);
   d_out.zero(bytes_out);
 
-  ccglib::packing::Packing packing(N, device, stream);
-  packing.Run(d_in, d_out, ccglib::backward);
+  ccglib::packing::Packing packing(N, ccglib::backward, device, stream);
+  packing.Run(d_in, d_out);
 
   // copy output to host
   stream.memcpyDtoHAsync(h_out, d_out, bytes_out);
@@ -136,10 +136,11 @@ TEST_CASE("Pack - unpack") {
   d_packed.zero(bytes_packed);
   d_out.zero(bytes_packed);
 
-  ccglib::packing::Packing packing(N, device, stream);
+  ccglib::packing::Packing packing(N, ccglib::forward, device, stream);
+  ccglib::packing::Packing unpacking(N, ccglib::backward, device, stream);
 
-  packing.Run(d_in, d_packed, ccglib::forward);
-  packing.Run(d_packed, d_out, ccglib::backward);
+  packing.Run(d_in, d_packed);
+  unpacking.Run(d_packed, d_out);
 
   // copy output to host
   stream.memcpyDtoHAsync(h_out, d_out, bytes_unpacked);
@@ -177,8 +178,9 @@ TEST_CASE("Packing - complex-interleaved") {
   cu::DeviceMemory d_out(bytes_out);
   d_out.zero(bytes_out);
 
-  ccglib::packing::Packing packing(N, device, stream);
-  packing.Run(d_in, d_out, ccglib::forward, ccglib::complex_interleaved);
+  ccglib::packing::Packing packing(N, ccglib::forward, device, stream,
+                                   ccglib::complex_interleaved);
+  packing.Run(d_in, d_out);
 
   // copy output to host
   stream.memcpyDtoHAsync(h_out, d_out, bytes_out);

--- a/test/pipeline/pipeline.cpp
+++ b/test/pipeline/pipeline.cpp
@@ -144,10 +144,12 @@ TEST_CASE("Pipeline int1 - int32") {
   stream.memcpyHtoDAsync(d_a_packed, h_a_packed, d_a_packed.size());
   stream.memcpyHtoDAsync(d_b_packed, h_b_packed, d_b_packed.size());
 
-  ccglib::packing::Packing pack_a(num_a, device, stream);
-  ccglib::packing::Packing pack_b(num_a, device, stream);
-  pack_a.Run(d_a_packed, d_a, ccglib::backward, input_complex_axis_location);
-  pack_b.Run(d_b_packed, d_b, ccglib::backward, input_complex_axis_location);
+  ccglib::packing::Packing unpack_a(num_a, ccglib::backward, device, stream,
+                                    input_complex_axis_location);
+  ccglib::packing::Packing unpack_b(num_a, ccglib::backward, device, stream,
+                                    input_complex_axis_location);
+  unpack_a.Run(d_a_packed, d_a);
+  unpack_b.Run(d_b_packed, d_b);
 
   cu::DeviceMemory d_c(h_c.size());
   d_c.zero(d_c.size());


### PR DESCRIPTION
This make the Packing class consistent with the others: the only arguments to Run are the input/output arrays.

Closes #14 