### PR TITLE
Add compatibility with HIP 7

### DIFF
--- a/kernels/matrix_operations.h
+++ b/kernels/matrix_operations.h
@@ -11,8 +11,8 @@ namespace wmma = rocwmma;
 using namespace nvcuda;
 #endif
 
-// The following is a workaround for the lack of __syncwarp() in HIP
-#if defined(__HIP_PLATFORM_AMD__)
+// The following is a workaround for the lack of __syncwarp() in HIP<7
+#if defined(__HIP_PLATFORM_AMD__) && HIP_VERSION_MAJOR < 7
 inline __device__ void __syncwarp(){};
 #endif
 

--- a/kernels/packing_kernel.cu
+++ b/kernels/packing_kernel.cu
@@ -7,7 +7,7 @@
 extern "C" __global__ void pack_bits(unsigned *output,
                                      const unsigned char *input) {
   size_t tid = threadIdx.x + blockIdx.x * static_cast<size_t>(blockDim.x);
-  if (tid >= N) {
+  if (tid >= N_GLOBAL) {
     return;
   }
 
@@ -16,8 +16,8 @@ extern "C" __global__ void pack_bits(unsigned *output,
   // map from real0, real1, .... imag0, imag1... indexing to
   // real0, imag0, real1, imag1, ...
   input_index *= 2;
-  if (input_index >= N) {
-    input_index -= N - 1;
+  if (input_index >= N_GLOBAL) {
+    input_index -= N_GLOBAL - 1;
   }
 #endif
 
@@ -37,7 +37,7 @@ extern "C" __global__ void pack_bits(unsigned *output,
     // case.
     const size_t index = 2 * (tid / WARP_SIZE);
     const unsigned nr_bits = sizeof(unsigned) * CHAR_BIT;
-    if (index == (N / nr_bits - 1)) {
+    if (index == (N_GLOBAL / nr_bits - 1)) {
       output[index] = output_value & 0xFFFFFFFF;
     } else {
       reinterpret_cast<unsigned long *>(output)[tid / WARP_SIZE] = output_value;
@@ -51,7 +51,7 @@ extern "C" __global__ void pack_bits(unsigned *output,
 extern "C" __global__ void unpack_bits(unsigned char *output,
                                        const unsigned *input) {
   size_t tid = threadIdx.x + blockIdx.x * static_cast<size_t>(blockDim.x);
-  if (tid >= N) {
+  if (tid >= N_GLOBAL) {
     return;
   }
 

--- a/src/packing/Packing.cpp
+++ b/src/packing/Packing.cpp
@@ -92,7 +92,7 @@ void Packing::Impl::compile_kernel() {
     "-DHIP_ENABLE_WARP_SYNC_BUILTINS",
 #endif
     "-I" + cuda_include_path,
-    "-DN=" + std::to_string(N_) + "UL",
+    "-DN_GLOBAL=" + std::to_string(N_) + "UL",
     "-DWARP_SIZE=" + std::to_string(warp_size)
   };
 

--- a/src/packing/Packing.cpp
+++ b/src/packing/Packing.cpp
@@ -87,8 +87,8 @@ void Packing::Impl::compile_kernel() {
 #else
     "-arch=" + arch,
 #endif
-#if defined(__HIP_PLATFORM_AMD__)
-    // HIP does not enable warp sync functions by default (yet) in ROCm 6.2
+#if defined(__HIP_PLATFORM_AMD__) && HIP_VERSION_MAJOR < 7
+    // HIP does not enable warp sync functions by default (yet) in ROCm 6.x
     "-DHIP_ENABLE_WARP_SYNC_BUILTINS",
 #endif
     "-I" + cuda_include_path,


### PR DESCRIPTION
* HIP now includes `__syncwarp`.
* N is now used in `hiprtc` as template argument, so cannot be `defined` in ccglib kernels.
* warp sync function are enabled by default.