### PR TITLE
Set PATH and CXX for HIP test workflow

### DIFF
--- a/.github/workflows/test_hip.yml
+++ b/.github/workflows/test_hip.yml
@@ -16,8 +16,7 @@ jobs:
           gres: gpu:W7700
           time: "00:10:00"
           commands: |
-            # HIP is installed locally
-            cmake -S . -B build -DCCGLIB_BUILD_TESTING=1 -DCCGLIB_BACKEND=HIP
+            CXX=hipcc PATH=$PATH:/opt/rocm/bin cmake -S . -B build -DCCGLIB_BUILD_TESTING=1 -DCCGLIB_BACKEND=HIP
             make -C build -j
             cd build
             ctest --output-on-failure


### PR DESCRIPTION
After an update of the node image on DAS-6, ROCm is no longer detected. This is fixed by adding the ROCm binary directory to the `PATH` and by setting the C++ compiler (to avoid a conflict between `clang` and `gcc`).