### PR TITLE
Implement syncwarp for HIP<7

### DIFF
--- a/kernels/matrix_operations.h
+++ b/kernels/matrix_operations.h
@@ -12,8 +12,13 @@ using namespace nvcuda;
 #endif
 
 // The following is a workaround for the lack of __syncwarp() in HIP<7
+// The implementation is identical to that in HIP 7.0
 #if defined(__HIP_PLATFORM_AMD__) && HIP_VERSION_MAJOR < 7
-inline __device__ void __syncwarp(){};
+inline __device__ void __syncwarp() {
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "wavefront");
+  __builtin_amdgcn_wave_barrier();
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "wavefront");
+}
 #endif
 
 inline __device__ size_t global_idx_m(const size_t &blockM, const size_t &warpM,


### PR DESCRIPTION
HIP 7 added `__syncwarp`, see https://github.com/ROCm/rocm-systems/blob/470b7d7ccd40c3476e3b21fa77328344308ac602/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h#L170

The implementation using builtins also works  in HIP 6 (tested in 6.0 and 6.4), so for maximum compatibility the same implementation is added to ccglib.