### PR TITLE
Implement scaling with alpha/beta

### DIFF
--- a/include/ccglib/gemm/mma.h
+++ b/include/ccglib/gemm/mma.h
@@ -31,7 +31,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major);
+       MemOrder b_mem_order = MemOrder::col_major, float alpha = 1,
+       float beta = 0);
   ~GEMM();
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
   static dim3 GetDimensions(Precision precision,
@@ -43,7 +44,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major);
+       MemOrder b_mem_order = MemOrder::col_major, float alpha = 1,
+       float beta = 0);
   void Run(hipDeviceptr_t d_a, hipDeviceptr_t d_b, hipDeviceptr_t d_c);
 #else
   GEMM(size_t B_, size_t M_, size_t N_, size_t K_, CUdevice &device,
@@ -52,7 +54,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major);
+       MemOrder b_mem_order = MemOrder::col_major, float alpha = 1,
+       float beta = 0);
   void Run(CUdeviceptr d_a, CUdeviceptr d_b, CUdeviceptr d_c);
 #endif
 

--- a/include/ccglib/gemm/mma.h
+++ b/include/ccglib/gemm/mma.h
@@ -31,8 +31,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major, float alpha = 1,
-       float beta = 0);
+       MemOrder b_mem_order = MemOrder::col_major, float2 alpha = {1, 0},
+       float2 beta = {0, 0});
   ~GEMM();
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
   static dim3 GetDimensions(Precision precision,
@@ -44,8 +44,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major, float alpha = 1,
-       float beta = 0);
+       MemOrder b_mem_order = MemOrder::col_major, float2 alpha = {1, 0},
+       float2 beta = {0, 0});
   void Run(hipDeviceptr_t d_a, hipDeviceptr_t d_b, hipDeviceptr_t d_c);
 #else
   GEMM(size_t B_, size_t M_, size_t N_, size_t K_, CUdevice &device,
@@ -54,8 +54,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major, float alpha = 1,
-       float beta = 0);
+       MemOrder b_mem_order = MemOrder::col_major, float2 alpha = {1, 0},
+       float2 beta = {0, 0});
   void Run(CUdeviceptr d_a, CUdeviceptr d_b, CUdeviceptr d_c);
 #endif
 

--- a/include/ccglib/gemm/mma.h
+++ b/include/ccglib/gemm/mma.h
@@ -1,6 +1,7 @@
 #ifndef MMA_GEMM_H_
 #define MMA_GEMM_H_
 
+#include <complex>
 #include <memory>
 
 #include <ccglib/common/complex_order.h>
@@ -31,8 +32,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major, float2 alpha = {1, 0},
-       float2 beta = {0, 0});
+       MemOrder b_mem_order = MemOrder::col_major,
+       std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   ~GEMM();
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
   static dim3 GetDimensions(Precision precision,
@@ -44,8 +45,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major, float2 alpha = {1, 0},
-       float2 beta = {0, 0});
+       MemOrder b_mem_order = MemOrder::col_major,
+       std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   void Run(hipDeviceptr_t d_a, hipDeviceptr_t d_b, hipDeviceptr_t d_c);
 #else
   GEMM(size_t B_, size_t M_, size_t N_, size_t K_, CUdevice &device,
@@ -54,8 +55,8 @@ public:
            ComplexAxisLocation::complex_planar,
        MemOrder c_mem_order = MemOrder::row_major,
        MemOrder a_mem_order = MemOrder::row_major,
-       MemOrder b_mem_order = MemOrder::col_major, float2 alpha = {1, 0},
-       float2 beta = {0, 0});
+       MemOrder b_mem_order = MemOrder::col_major,
+       std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   void Run(CUdeviceptr d_a, CUdeviceptr d_b, CUdeviceptr d_c);
 #endif
 

--- a/include/ccglib/gemm/reference.h
+++ b/include/ccglib/gemm/reference.h
@@ -10,29 +10,36 @@ class GEMM {
 public:
   virtual void
   Run(const half *a, const half *b, half *c, size_t M, size_t N, size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
   virtual void
   Run(const half *a, const half *b, float *c, size_t M, size_t N, size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
   virtual void
   Run(const float *a, const float *b, half *c, size_t M, size_t N, size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
   virtual void
   Run(const bf16 *a, const bf16 *b, bf16 *c, size_t M, size_t N, size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
   virtual void
   Run(const bf16 *a, const bf16 *b, float *c, size_t M, size_t N, size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
   virtual void
   Run(const float *a, const float *b, bf16 *c, size_t M, size_t N, size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
   virtual void
   Run(const float *a, const float *b, float *c, size_t M, size_t N, size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
   virtual void
   Run(const unsigned *a, const unsigned *b, int *c, size_t M, size_t N,
-      size_t K,
-      ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major);
+      size_t K, ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
+      float2 alpha = {1, 0}, float2 beta = {0, 0});
 };
 
 } // namespace ccglib::reference

--- a/include/ccglib/gemm/reference.h
+++ b/include/ccglib/gemm/reference.h
@@ -1,6 +1,8 @@
 #ifndef REFERENCE_GEMM_H_
 #define REFERENCE_GEMM_H_
 
+#include <complex>
+
 #include <ccglib/bf16.h>
 #include <ccglib/fp16.h>
 #include <ccglib/gemm/mem_order.h>
@@ -11,35 +13,35 @@ public:
   virtual void
   Run(const half *a, const half *b, half *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   virtual void
   Run(const half *a, const half *b, float *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   virtual void
   Run(const float *a, const float *b, half *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   virtual void
   Run(const bf16 *a, const bf16 *b, bf16 *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   virtual void
   Run(const bf16 *a, const bf16 *b, float *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   virtual void
   Run(const float *a, const float *b, bf16 *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   virtual void
   Run(const float *a, const float *b, float *c, size_t M, size_t N, size_t K,
       ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
   virtual void
   Run(const unsigned *a, const unsigned *b, int *c, size_t M, size_t N,
       size_t K, ccglib::mma::MemOrder output_mem_order = ccglib::mma::row_major,
-      float2 alpha = {1, 0}, float2 beta = {0, 0});
+      std::complex<float> alpha = {1, 0}, std::complex<float> beta = {0, 0});
 };
 
 } // namespace ccglib::reference

--- a/include/ccglib/pipeline/pipeline.h
+++ b/include/ccglib/pipeline/pipeline.h
@@ -69,7 +69,7 @@ private:
   std::unique_ptr<Impl> impl_;
   std::unique_ptr<cu::Device> device_;
   std::unique_ptr<cu::Stream> stream_;
-  const bool need_copy_in_c_;
+  const bool need_copyin_c_;
 };
 
 } // namespace ccglib::pipeline

--- a/include/ccglib/pipeline/pipeline.h
+++ b/include/ccglib/pipeline/pipeline.h
@@ -1,6 +1,7 @@
 #ifndef PIPELINE_H_
 #define PIPELINE_H_
 
+#include <complex>
 #include <memory>
 
 #ifdef __HIP__
@@ -32,7 +33,9 @@ public:
            mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
            mma::MemOrder c_mem_order, ValuePrecision input_precision,
            ValuePrecision output_precision,
-           mma::Variant variant = mma::Variant::opt);
+           mma::Variant variant = mma::Variant::opt,
+           std::complex<float> alpha = {1, 0},
+           std::complex<float> beta = {0, 0});
   ~Pipeline();
   void Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c);
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
@@ -44,7 +47,9 @@ public:
            mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
            mma::MemOrder c_mem_order, ValuePrecision input_precision,
            ValuePrecision output_precision,
-           mma::Variant variant = mma::Variant::opt);
+           mma::Variant variant = mma::Variant::opt,
+           std::complex<float> alpha = {1, 0},
+           std::complex<float> beta = {0, 0});
   void Run(hipDeviceptr_t a, hipDeviceptr_t b, hipDeviceptr_t c);
 #else
   Pipeline(size_t B, size_t M, size_t N, size_t K, CUdevice &device,
@@ -53,7 +58,9 @@ public:
            mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
            mma::MemOrder c_mem_order, ValuePrecision input_precision,
            ValuePrecision output_precision,
-           mma::Variant variant = mma::Variant::opt);
+           mma::Variant variant = mma::Variant::opt,
+           std::complex<float> alpha = {1, 0},
+           std::complex<float> beta = {0, 0});
   void Run(CUdeviceptr a, CUdeviceptr b, CUdeviceptr c);
 #endif
 

--- a/include/ccglib/pipeline/pipeline.h
+++ b/include/ccglib/pipeline/pipeline.h
@@ -69,6 +69,7 @@ private:
   std::unique_ptr<Impl> impl_;
   std::unique_ptr<cu::Device> device_;
   std::unique_ptr<cu::Stream> stream_;
+  const bool need_copy_in_c_;
 };
 
 } // namespace ccglib::pipeline

--- a/kernels/gemm_kernel_float.cu
+++ b/kernels/gemm_kernel_float.cu
@@ -65,8 +65,8 @@ extern "C" __global__ void wmma_complex_gemm_basic(C_t C, const A_t A,
 #endif
 
 #if REQUIRES_SHARED_MEMORY
-  __shared__ Tshared C_s[M_PER_BLOCK / M_PER_WARP][N_PER_BLOCK / N_PER_WARP]
-                        [M_PER_WMMA][N_PER_WMMA];
+  __shared__ Tshared C_s[COMPLEX][M_PER_BLOCK / M_PER_WARP]
+                        [N_PER_BLOCK / N_PER_WARP][M_PER_WMMA][N_PER_WMMA];
 #endif
 
   for (size_t k = 0; k < K_TILES; k++) {
@@ -218,7 +218,8 @@ extern "C" __global__ void wmma_complex_gemm_opt(C_t C, const A_opt_t A,
                      [K_PER_WMMA];
   A_s_t A_s = reinterpret_cast<A_s_t>(&shmem[0]);
   B_s_t B_s = reinterpret_cast<B_s_t>(&shmem[A_s_size]);
-  typedef Tshared(*C_s_t)[N_PER_BLOCK / N_PER_WARP][M_PER_WMMA][N_PER_WMMA];
+  typedef Tshared(*C_s_t)[M_PER_BLOCK / M_PER_WARP][N_PER_BLOCK / N_PER_WARP]
+                         [M_PER_WMMA][N_PER_WMMA];
 #if REQUIRES_SHARED_MEMORY
   C_s_t C_s = reinterpret_cast<C_s_t>(&shmem[0]);
 #endif

--- a/kernels/gemm_kernel_float.cu
+++ b/kernels/gemm_kernel_float.cu
@@ -10,9 +10,6 @@ namespace wmma = rocwmma;
 using namespace nvcuda;
 #endif
 
-#define HAVE_ALHPA 1
-#define HAVE_BETA 1
-
 #include "ccglib/bf16.h"
 #include "ccglib/fp16.h"
 

--- a/kernels/gemm_kernel_float.cu
+++ b/kernels/gemm_kernel_float.cu
@@ -10,6 +10,9 @@ namespace wmma = rocwmma;
 using namespace nvcuda;
 #endif
 
+#define HAVE_ALHPA 1
+#define HAVE_BETA 1
+
 #include "ccglib/bf16.h"
 #include "ccglib/fp16.h"
 

--- a/kernels/gemm_kernel_int1.cu
+++ b/kernels/gemm_kernel_int1.cu
@@ -245,8 +245,8 @@ extern "C" __global__ void wmma_complex_gemm_opt(C_t C, const A_opt_t A,
   A_s_t &A_s = *reinterpret_cast<A_s_t *>(shmem.ab);
   B_s_t &B_s = *reinterpret_cast<B_s_t *>(&shmem.ab[A_s_size]);
 #if defined(C_COMPLEX_INTERLEAVED)
-  using C_s_t = Tout[M_PER_BLOCK / M_PER_WARP][N_PER_BLOCK / N_PER_WARP]
-                    [M_PER_WMMA][N_PER_WMMA];
+  using C_s_t = Tout[COMPLEX][M_PER_BLOCK / M_PER_WARP]
+                    [N_PER_BLOCK / N_PER_WARP][M_PER_WMMA][N_PER_WMMA];
   C_s_t &C_s = *reinterpret_cast<C_s_t *>(shmem.c);
 #endif
 

--- a/kernels/matrix_operations.h
+++ b/kernels/matrix_operations.h
@@ -53,6 +53,7 @@ store_matrix(Accumulator_t sum[COMPLEX][M_PER_WARP / M_PER_WMMA]
       wmma::load_matrix_sync(c_frag[IMAG], &(C[batch][IMAG][idx_n][idx_m]),
                              M_GLOBAL, wmma::mem_col_major);
 #endif
+      __syncwarp();
 #endif
       for (size_t i = 0; i < sum[REAL][m][n].num_elements; i++) {
         const Tshared sum_real = sum[REAL][m][n].x[i];
@@ -70,6 +71,7 @@ store_matrix(Accumulator_t sum[COMPLEX][M_PER_WARP / M_PER_WMMA]
                                 static_cast<Tshared>(BETA_REAL) * c_imag;
 #endif
       }
+      __syncwarp();
     }
   }
 #endif

--- a/kernels/matrix_operations.h
+++ b/kernels/matrix_operations.h
@@ -55,19 +55,19 @@ store_matrix(Accumulator_t sum[COMPLEX][M_PER_WARP / M_PER_WMMA]
 #endif
 #endif
       for (size_t i = 0; i < sum[REAL][m][n].num_elements; i++) {
-        Tshared &sum_real = sum[REAL][m][n].x[i];
-        Tshared &sum_imag = sum[IMAG][m][n].x[i];
-        sum_real = static_cast<Tshared>(ALPHA_REAL) * sum_real -
-                   static_cast<Tshared>(ALPHA_IMAG) * sum_imag;
-        sum_imag = static_cast<Tshared>(ALPHA_IMAG) * sum_real +
-                   static_cast<Tshared>(ALPHA_REAL) * sum_imag;
+        const Tshared sum_real = sum[REAL][m][n].x[i];
+        const Tshared sum_imag = sum[IMAG][m][n].x[i];
+        sum[REAL][m][n].x[i] = static_cast<Tshared>(ALPHA_REAL) * sum_real -
+                               static_cast<Tshared>(ALPHA_IMAG) * sum_imag;
+        sum[IMAG][m][n].x[i] = static_cast<Tshared>(ALPHA_IMAG) * sum_real +
+                               static_cast<Tshared>(ALPHA_REAL) * sum_imag;
 #if defined(HAVE_BETA)
-        Tshared &c_real = c_frag[REAL].x[i];
-        Tshared &c_imag = c_frag[IMAG].x[i];
-        sum_real += static_cast<Tshared>(BETA_REAL) * c_real -
-                    static_cast<Tshared>(BETA_IMAG) * c_imag;
-        sum_imag += static_cast<Tshared>(BETA_IMAG) * c_real +
-                    static_cast<Tshared>(BETA_REAL) * c_imag;
+        const Tshared c_real = c_frag[REAL].x[i];
+        const Tshared c_imag = c_frag[IMAG].x[i];
+        sum[REAL][m][n].x[i] += static_cast<Tshared>(BETA_REAL) * c_real -
+                                static_cast<Tshared>(BETA_IMAG) * c_imag;
+        sum[IMAG][m][n].x[i] += static_cast<Tshared>(BETA_IMAG) * c_real +
+                                static_cast<Tshared>(BETA_REAL) * c_imag;
 #endif
       }
     }

--- a/kernels/matrix_operations.h
+++ b/kernels/matrix_operations.h
@@ -103,44 +103,50 @@ store_matrix_padded(Accumulator_t sum[COMPLEX][M_PER_WARP / M_PER_WMMA]
                     const size_t &warpN, const size_t &M_TILES,
                     const size_t &N_TILES) {
 
-#if defined(C_COMPLEX_PLANAR)
-  for (size_t c = 0; c < COMPLEX; c++) {
-    for (size_t m = 0; m < M_TILES; m++) {
-      for (size_t n = 0; n < N_TILES; n++) {
-#else
   for (size_t m = 0; m < M_TILES; m++) {
     for (size_t n = 0; n < N_TILES; n++) {
-      for (size_t c = 0; c < COMPLEX; c++) {
-#endif
-        wmma::store_matrix_sync(&C_s[warpM][warpN][0][0], sum[c][m][n],
-                                N_PER_WMMA, wmma::mem_row_major);
+      wmma::store_matrix_sync(&C_s[REAL][warpM][warpN][0][0], sum[REAL][m][n],
+                              N_PER_WMMA, wmma::mem_row_major);
+      wmma::store_matrix_sync(&C_s[IMAG][warpM][warpN][0][0], sum[IMAG][m][n],
+                              N_PER_WMMA, wmma::mem_row_major);
 
-        __syncwarp();
-        size_t m_index = global_idx_m(blockM, warpM, m);
-        size_t n_index = global_idx_n(blockN, warpN, n);
-        for (size_t t = threadIdx.x; t < M_PER_WMMA * N_PER_WMMA;
-             t += WARP_SIZE) {
-          size_t i = t / N_PER_WMMA;
-          size_t j = t % N_PER_WMMA;
-          // store the submatrix, padded values are set to zero
-          if (m_index + i < M_GLOBAL && n_index + j < N_GLOBAL) {
+      __syncwarp();
+      size_t m_index = global_idx_m(blockM, warpM, m);
+      size_t n_index = global_idx_n(blockN, warpN, n);
+      for (size_t t = threadIdx.x; t < M_PER_WMMA * N_PER_WMMA;
+           t += WARP_SIZE) {
+        size_t i = t / N_PER_WMMA;
+        size_t j = t % N_PER_WMMA;
+        // store the submatrix, padded values are set to zero
+        if (m_index + i < M_GLOBAL && n_index + j < N_GLOBAL) {
 #if defined(C_ROW_MAJOR)
 #if defined(C_COMPLEX_PLANAR)
-            C[batch][c][m_index + i][n_index + j] = C_s[warpM][warpN][i][j];
+          C[batch][REAL][m_index + i][n_index + j] =
+              C_s[REAL][warpM][warpN][i][j];
+          C[batch][IMAG][m_index + i][n_index + j] =
+              C_s[IMAG][warpM][warpN][i][j];
 #else
-            C[batch][m_index + i][n_index + j][c] = C_s[warpM][warpN][i][j];
+          C[batch][m_index + i][n_index + j][REAL] =
+              C_s[REAL][warpM][warpN][i][j];
+          C[batch][m_index + i][n_index + j][IMAG] =
+              C_s[IMAG][warpM][warpN][i][j];
 #endif
 #else
 #if defined(C_COMPLEX_PLANAR)
-            C[batch][c][n_index + j][m_index + i] = C_s[warpM][warpN][i][j];
+          C[batch][REAL][n_index + j][m_index + i] =
+              C_s[REAL][warpM][warpN][i][j];
+          C[batch][IMAG][n_index + j][m_index + i] =
+              C_s[IMAG][warpM][warpN][i][j];
 #else
-            C[batch][n_index + j][m_index + i][c] = C_s[warpM][warpN][i][j];
+          C[batch][n_index + j][m_index + i][REAL] =
+              C_s[IMAG][warpM][warpN][i][j];
+          C[batch][n_index + j][m_index + i][IMAG] =
+              C_s[IMAG][warpM][warpN][i][j];
 #endif
 #endif
-          }
         }
-        __syncwarp();
       }
+      __syncwarp();
     }
   }
 }

--- a/kernels/type_selector.h
+++ b/kernels/type_selector.h
@@ -212,7 +212,7 @@ constexpr size_t A_s_size =
 constexpr size_t B_s_size =
     NBUFFER * COMPLEX * N_PER_BLOCK * K_PER_WMMA / DeviceTraits::PACKING_FACTOR;
 
-constexpr size_t C_s_size = (M_PER_BLOCK / M_PER_WARP) *
+constexpr size_t C_s_size = COMPLEX * (M_PER_BLOCK / M_PER_WARP) *
                             (N_PER_BLOCK / N_PER_WARP) * M_PER_WMMA *
                             N_PER_WMMA;
 static_assert((A_s_size + B_s_size) * sizeof(Tin) >= C_s_size * sizeof(Tout),

--- a/kernels/wmma_extension.h
+++ b/kernels/wmma_extension.h
@@ -88,6 +88,23 @@ store_matrix_sync(int *p, const fragment<accumulator, 16, 8, 256, int> &d,
     p[(laneid() % 4) * 2 * ldm + (laneid() / 4 + 8) + ldm] = d.x[3];
   }
 }
+
+inline __device__ void
+load_matrix_sync(fragment<accumulator, 16, 8, 256, int> &c, const void *p,
+                 size_t ldm, layout_t layout) {
+  return;
+  if (layout == mem_row_major) {
+    c.x[0] = ((int *)p)[ldm / 2 * (laneid() / 4) + laneid() % 4];
+    c.x[1] = ((int *)p)[ldm / 2 * (laneid() / 4) + laneid() % 4 + 1];
+    c.x[2] = ((int *)p)[ldm / 2 * (laneid() / 4 + 8) + laneid() % 4];
+    c.x[3] = ((int *)p)[ldm / 2 * (laneid() / 4 + 8) + laneid() % 4 + 1];
+  } else {
+    c.x[0] = ((int *)p)[(laneid() % 4) * 2 * ldm + (laneid() / 4)];
+    c.x[1] = ((int *)p)[(laneid() % 4) * 2 * ldm + (laneid() / 4) + ldm];
+    c.x[2] = ((int *)p)[(laneid() % 4) * 2 * ldm + (laneid() / 4 + 8)];
+    c.x[3] = ((int *)p)[(laneid() % 4) * 2 * ldm + (laneid() / 4 + 8 + ldm)];
+  }
+}
 #endif
 } // namespace wmma
 } // namespace nvcuda

--- a/kernels/wmma_extension.h
+++ b/kernels/wmma_extension.h
@@ -92,12 +92,11 @@ store_matrix_sync(int *p, const fragment<accumulator, 16, 8, 256, int> &d,
 inline __device__ void
 load_matrix_sync(fragment<accumulator, 16, 8, 256, int> &c, const void *p,
                  size_t ldm, layout_t layout) {
-  return;
   if (layout == mem_row_major) {
-    c.x[0] = ((int *)p)[ldm / 2 * (laneid() / 4) + laneid() % 4];
-    c.x[1] = ((int *)p)[ldm / 2 * (laneid() / 4) + laneid() % 4 + 1];
-    c.x[2] = ((int *)p)[ldm / 2 * (laneid() / 4 + 8) + laneid() % 4];
-    c.x[3] = ((int *)p)[ldm / 2 * (laneid() / 4 + 8) + laneid() % 4 + 1];
+    c.x[0] = ((int *)p)[ldm * (laneid() / 4) + (laneid() % 4) * 2];
+    c.x[1] = ((int *)p)[ldm * (laneid() / 4) + (laneid() % 4) * 2 + 1];
+    c.x[2] = ((int *)p)[ldm * (laneid() / 4 + 8) + (laneid() % 4) * 2];
+    c.x[3] = ((int *)p)[ldm * (laneid() / 4 + 8) + (laneid() % 4) * 2 + 1];
   } else {
     c.x[0] = ((int *)p)[(laneid() % 4) * 2 * ldm + (laneid() / 4)];
     c.x[1] = ((int *)p)[(laneid() % 4) * 2 * ldm + (laneid() / 4) + ldm];

--- a/src/mma/GEMM.cpp
+++ b/src/mma/GEMM.cpp
@@ -19,7 +19,7 @@ public:
   Impl(size_t B_, size_t M_, size_t N_, size_t K_, cu::Device &device_,
        cu::Stream &stream_, Precision precision, Variant variant,
        ComplexAxisLocation c_complex_axis_location, MemOrder c_mem_order,
-       MemOrder a_mem_order, MemOrder b_mem_order);
+       MemOrder a_mem_order, MemOrder b_mem_order, float alpha, float beta);
 
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
 
@@ -38,6 +38,8 @@ private:
   size_t K_;
   size_t M_;
   size_t N_;
+  float alpha_;
+  float beta_;
 
   dim3 threads_;
   dim3 grid_;
@@ -53,11 +55,12 @@ GEMM::Impl::Impl(size_t B_, size_t M_, size_t N_, size_t K_,
                  cu::Device &device_, cu::Stream &stream_, Precision precision,
                  Variant variant, ComplexAxisLocation c_complex_axis_location,
                  MemOrder a_mem_order, MemOrder b_mem_order,
-                 MemOrder c_mem_order)
+                 MemOrder c_mem_order, float alpha, float beta)
     : B_(B_), M_(M_), N_(N_), K_(K_), device_(device_), stream_(stream_),
       c_complex_axis_location_(c_complex_axis_location), variant_(variant),
       c_mem_order_(c_mem_order), a_mem_order_(a_mem_order),
-      b_mem_order_(b_mem_order), kernel_(Kernel(precision, variant)) {
+      b_mem_order_(b_mem_order), alpha_(alpha), beta_(beta),
+      kernel_(Kernel(precision, variant)) {
   const Kernel::Parameters parameters = kernel_.GetParameters();
   threads_ = kernel_.GetThreads(device_);
   grid_ = dim3(ccglib::helper::ceildiv(N_, parameters.n_per_block),
@@ -137,6 +140,8 @@ void GEMM::Impl::compile_kernel() {
     "-DK_GLOBAL=" + std::to_string(K_) + "UL",
     "-DK_PADDING=" + std::to_string(0) +
         "UL", // will be required when K is not a multiple of K_PER_WMMA
+    "-DALPHA=" + std::to_string(alpha_),
+    "-DBETA=" + std::to_string(beta_),
     "-DTYPE_IN=" + std::to_string(static_cast<ValueType>(
                        kernel_.GetPrecision().input_type)),
     "-DTYPE_OUT=" + std::to_string(static_cast<ValueType>(
@@ -153,6 +158,10 @@ void GEMM::Impl::compile_kernel() {
     "-DK_PER_WMMA=" + std::to_string(parameters.k_per_wmma),
     "-DNBUFFER=" + std::to_string(parameters.nbuffer)
   };
+
+  for (auto &item : options) {
+    std::cout << item << std::endl;
+  }
 
   if (c_complex_axis_location_ == ComplexAxisLocation::complex_planar) {
     options.push_back("-DC_COMPLEX_PLANAR");
@@ -179,6 +188,14 @@ void GEMM::Impl::compile_kernel() {
     options.push_back("-DC_COL_MAJOR");
   }
 
+  if (alpha_ != 1) {
+    options.push_back("-DHAVE_ALPHA");
+  }
+
+  if (beta_ != 0) {
+    options.push_back("-DHAVE_BETA");
+  }
+
   nvrtc::Program program(kernel_.GetSource(), "gemm_kernel.cu");
 
   try {
@@ -199,21 +216,22 @@ GEMM::GEMM(const size_t B_, const size_t M_, const size_t N_, const size_t K_,
            const Variant variant,
            const ComplexAxisLocation c_complex_axis_location,
            const MemOrder c_mem_order, const MemOrder a_mem_order,
-           const MemOrder b_mem_order)
+           const MemOrder b_mem_order, const float alpha, const float beta)
     : impl_(std::make_unique<Impl>(B_, M_, N_, K_, device, stream, precision,
                                    variant, c_complex_axis_location,
-                                   a_mem_order, b_mem_order, c_mem_order)){};
+                                   a_mem_order, b_mem_order, c_mem_order, alpha,
+                                   beta)){};
 
 GEMM::GEMM(const size_t B_, const size_t M_, const size_t N_, const size_t K_,
            CUdevice &device, CUstream &stream, const Precision precision,
            const Variant variant,
            const ComplexAxisLocation c_complex_axis_location,
            const MemOrder c_mem_order, const MemOrder a_mem_order,
-           const MemOrder b_mem_order)
+           const MemOrder b_mem_order, const float alpha, const float beta)
     : device_(new cu::Device(device)), stream_(new cu::Stream(stream)) {
   impl_ = std::make_unique<Impl>(B_, M_, N_, K_, *device_, *stream_, precision,
                                  variant, c_complex_axis_location, a_mem_order,
-                                 b_mem_order, c_mem_order);
+                                 b_mem_order, c_mem_order, alpha, beta);
 }
 
 GEMM::~GEMM() = default;

--- a/src/mma/GEMM.cpp
+++ b/src/mma/GEMM.cpp
@@ -19,7 +19,7 @@ public:
   Impl(size_t B_, size_t M_, size_t N_, size_t K_, cu::Device &device_,
        cu::Stream &stream_, Precision precision, Variant variant,
        ComplexAxisLocation c_complex_axis_location, MemOrder c_mem_order,
-       MemOrder a_mem_order, MemOrder b_mem_order, float alpha, float beta);
+       MemOrder a_mem_order, MemOrder b_mem_order, float2 alpha, float2 beta);
 
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
 
@@ -38,8 +38,8 @@ private:
   size_t K_;
   size_t M_;
   size_t N_;
-  float alpha_;
-  float beta_;
+  float2 alpha_;
+  float2 beta_;
 
   dim3 threads_;
   dim3 grid_;
@@ -55,7 +55,7 @@ GEMM::Impl::Impl(size_t B_, size_t M_, size_t N_, size_t K_,
                  cu::Device &device_, cu::Stream &stream_, Precision precision,
                  Variant variant, ComplexAxisLocation c_complex_axis_location,
                  MemOrder a_mem_order, MemOrder b_mem_order,
-                 MemOrder c_mem_order, float alpha, float beta)
+                 MemOrder c_mem_order, float2 alpha, float2 beta)
     : B_(B_), M_(M_), N_(N_), K_(K_), device_(device_), stream_(stream_),
       c_complex_axis_location_(c_complex_axis_location), variant_(variant),
       c_mem_order_(c_mem_order), a_mem_order_(a_mem_order),
@@ -140,8 +140,10 @@ void GEMM::Impl::compile_kernel() {
     "-DK_GLOBAL=" + std::to_string(K_) + "UL",
     "-DK_PADDING=" + std::to_string(0) +
         "UL", // will be required when K is not a multiple of K_PER_WMMA
-    "-DALPHA=" + std::to_string(alpha_),
-    "-DBETA=" + std::to_string(beta_),
+    "-DALPHA_REAL=" + std::to_string(alpha_.x),
+    "-DALPHA_IMAG=" + std::to_string(alpha_.y),
+    "-DBETA_REAL=" + std::to_string(beta_.x),
+    "-DBETA_IMAG=" + std::to_string(beta_.y),
     "-DTYPE_IN=" + std::to_string(static_cast<ValueType>(
                        kernel_.GetPrecision().input_type)),
     "-DTYPE_OUT=" + std::to_string(static_cast<ValueType>(
@@ -158,10 +160,6 @@ void GEMM::Impl::compile_kernel() {
     "-DK_PER_WMMA=" + std::to_string(parameters.k_per_wmma),
     "-DNBUFFER=" + std::to_string(parameters.nbuffer)
   };
-
-  for (auto &item : options) {
-    std::cout << item << std::endl;
-  }
 
   if (c_complex_axis_location_ == ComplexAxisLocation::complex_planar) {
     options.push_back("-DC_COMPLEX_PLANAR");
@@ -188,11 +186,11 @@ void GEMM::Impl::compile_kernel() {
     options.push_back("-DC_COL_MAJOR");
   }
 
-  if (alpha_ != 1) {
+  if (alpha_.x != 1 || alpha_.y != 0) {
     options.push_back("-DHAVE_ALPHA");
   }
 
-  if (beta_ != 0) {
+  if (beta_.x != 0 || beta_.y != 0) {
     options.push_back("-DHAVE_BETA");
   }
 
@@ -216,7 +214,7 @@ GEMM::GEMM(const size_t B_, const size_t M_, const size_t N_, const size_t K_,
            const Variant variant,
            const ComplexAxisLocation c_complex_axis_location,
            const MemOrder c_mem_order, const MemOrder a_mem_order,
-           const MemOrder b_mem_order, const float alpha, const float beta)
+           const MemOrder b_mem_order, const float2 alpha, const float2 beta)
     : impl_(std::make_unique<Impl>(B_, M_, N_, K_, device, stream, precision,
                                    variant, c_complex_axis_location,
                                    a_mem_order, b_mem_order, c_mem_order, alpha,
@@ -227,7 +225,7 @@ GEMM::GEMM(const size_t B_, const size_t M_, const size_t N_, const size_t K_,
            const Variant variant,
            const ComplexAxisLocation c_complex_axis_location,
            const MemOrder c_mem_order, const MemOrder a_mem_order,
-           const MemOrder b_mem_order, const float alpha, const float beta)
+           const MemOrder b_mem_order, const float2 alpha, const float2 beta)
     : device_(new cu::Device(device)), stream_(new cu::Stream(stream)) {
   impl_ = std::make_unique<Impl>(B_, M_, N_, K_, *device_, *stream_, precision,
                                  variant, c_complex_axis_location, a_mem_order,

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -16,7 +16,8 @@ public:
        ComplexAxisLocation output_complex_axis_location,
        mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
        mma::MemOrder c_mem_order, ValuePrecision input_precision,
-       ValuePrecision output_precision, mma::Variant variant);
+       ValuePrecision output_precision, mma::Variant variant,
+       std::complex<float> alpha, std::complex<float> beta);
 
   void Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b, cu::DeviceMemory &d_c);
 
@@ -46,7 +47,8 @@ Pipeline::Impl::Impl(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
                      ComplexAxisLocation output_complex_axis_location,
                      mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
                      mma::MemOrder c_mem_order, ValuePrecision input_precision,
-                     ValuePrecision output_precision, mma::Variant variant)
+                     ValuePrecision output_precision, mma::Variant variant,
+                     std::complex<float> alpha, std::complex<float> beta)
     : requires_packing_(input_precision == ccglib::int1),
       requires_transpose_(variant == ccglib::mma::opt), device_(device),
       stream_(stream) {
@@ -99,7 +101,8 @@ Pipeline::Impl::Impl(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
 
   gemm_ = std::make_unique<ccglib::mma::GEMM>(
       B, M, N, K, device_, stream_, precision, variant,
-      output_complex_axis_location, c_mem_order, a_mem_order, b_mem_order);
+      output_complex_axis_location, c_mem_order, a_mem_order, b_mem_order,
+      alpha, beta);
 }
 
 void Pipeline::Impl::Run(cu::DeviceMemory &d_a, cu::DeviceMemory &d_b,
@@ -128,13 +131,14 @@ Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
                    ComplexAxisLocation output_complex_axis_location,
                    mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
                    mma::MemOrder c_mem_order, ValuePrecision input_precision,
-                   ValuePrecision output_precision, mma::Variant variant)
+                   ValuePrecision output_precision, mma::Variant variant,
+                   std::complex<float> alpha, std::complex<float> beta)
     : device_(std::make_unique<cu::Device>(device)),
       stream_(std::make_unique<cu::Stream>(stream)) {
   impl_ = std::make_unique<Impl>(
       B, M, N, K, *device_, *stream_, input_complex_axis_location,
       output_complex_axis_location, a_mem_order, b_mem_order, c_mem_order,
-      input_precision, output_precision, variant);
+      input_precision, output_precision, variant, alpha, beta);
 }
 
 Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, CUdevice &device,
@@ -143,13 +147,14 @@ Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, CUdevice &device,
                    ComplexAxisLocation output_complex_axis_location,
                    mma::MemOrder a_mem_order, mma::MemOrder b_mem_order,
                    mma::MemOrder c_mem_order, ValuePrecision input_precision,
-                   ValuePrecision output_precision, mma::Variant variant)
+                   ValuePrecision output_precision, mma::Variant variant,
+                   std::complex<float> alpha, std::complex<float> beta)
     : device_(std::make_unique<cu::Device>(device)),
       stream_(std::make_unique<cu::Stream>(stream)) {
   impl_ = std::make_unique<Impl>(
       B, M, N, K, *device_, *stream_, input_complex_axis_location,
       output_complex_axis_location, a_mem_order, b_mem_order, c_mem_order,
-      input_precision, output_precision, variant);
+      input_precision, output_precision, variant, alpha, beta);
 }
 
 void Pipeline::Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c) {

--- a/src/pipeline/Pipeline.cpp
+++ b/src/pipeline/Pipeline.cpp
@@ -133,7 +133,7 @@ Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, cu::Device &device,
                    mma::MemOrder c_mem_order, ValuePrecision input_precision,
                    ValuePrecision output_precision, mma::Variant variant,
                    std::complex<float> alpha, std::complex<float> beta)
-    : need_copy_in_c_(beta.real() != 0 || beta.imag() != 0),
+    : need_copyin_c_(beta.real() != 0 || beta.imag() != 0),
       device_(std::make_unique<cu::Device>(device)),
       stream_(std::make_unique<cu::Stream>(stream)) {
   impl_ = std::make_unique<Impl>(
@@ -150,7 +150,7 @@ Pipeline::Pipeline(size_t B, size_t M, size_t N, size_t K, CUdevice &device,
                    mma::MemOrder c_mem_order, ValuePrecision input_precision,
                    ValuePrecision output_precision, mma::Variant variant,
                    std::complex<float> alpha, std::complex<float> beta)
-    : need_copy_in_c_(beta.real() != 0 || beta.imag() != 0),
+    : need_copyin_c_(beta.real() != 0 || beta.imag() != 0),
       device_(std::make_unique<cu::Device>(device)),
       stream_(std::make_unique<cu::Stream>(stream)) {
   impl_ = std::make_unique<Impl>(
@@ -165,7 +165,7 @@ void Pipeline::Run(cu::HostMemory &a, cu::HostMemory &b, cu::HostMemory &c) {
   cu::DeviceMemory d_c(c.size());
   stream_->memcpyHtoDAsync(d_a, a, a.size());
   stream_->memcpyHtoDAsync(d_b, b, b.size());
-  if (need_copy_in_c_) {
+  if (need_copyin_c_) {
     stream_->memcpyHtoDAsync(d_c, c, c.size());
   } else {
     d_c.zero(d_c.size());

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -14,7 +14,7 @@
 namespace {
 template <typename Tin, typename Tout>
 void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
-         ccglib::mma::MemOrder output_mem_order) {
+         ccglib::mma::MemOrder output_mem_order, float2 alpha, float2 beta) {
   // Use float as the compute type when Tout is half or bf16 because tensor core
   // multiply-add operations execute in float precision. Otherwise, preserve
   // Tout.
@@ -58,12 +58,25 @@ void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
         sum_imag += term_imag;
       }
 
+      const ComputeType alpha_real = alpha.x;
+      const ComputeType alpha_imag = alpha.y;
+      const ComputeType beta_real = beta.x;
+      const ComputeType beta_imag = beta.y;
+
+      const ComputeType sum_real_copy = sum_real;
+      sum_real = alpha_real * sum_real - alpha_imag * sum_imag;
+      sum_imag = alpha_imag * sum_real_copy + alpha_real * sum_imag;
+
       if (output_mem_order == ccglib::mma::row_major) {
-        c_view(0, m, n) = sum_real;
-        c_view(1, m, n) = sum_imag;
+        const ComputeType c_real = c_view(0, m, n);
+        const ComputeType c_imag = c_view(1, m, n);
+        c_view(0, m, n) = sum_real + beta_real * c_real - beta_imag * c_imag;
+        c_view(1, m, n) = sum_imag + beta_imag * c_real + beta_real * c_imag;
       } else {
-        c_view(0, n, m) = sum_real;
-        c_view(1, n, m) = sum_imag;
+        const ComputeType c_real = c_view(0, n, m);
+        const ComputeType c_imag = c_view(1, n, m);
+        c_view(0, n, m) = sum_real + beta_real * c_real - beta_imag * c_imag;
+        c_view(1, n, m) = sum_imag + beta_imag * c_real + beta_real * c_imag;
       }
     }
   }
@@ -83,7 +96,8 @@ template <typename T> inline int popcount(T x) {
 }
 
 void run_binary(const unsigned *a, const unsigned *b, int *c, size_t M,
-                size_t N, size_t K, ccglib::mma::MemOrder output_mem_order) {
+                size_t N, size_t K, ccglib::mma::MemOrder output_mem_order,
+                float2 alpha, float2 beta) {
   // M, N, K are the number of 1-bit samples
   // the actual shape of the input data is different along the fastest changing
   // axis (=K) because values are packed into unsigned ints
@@ -174,12 +188,27 @@ void run_binary(const unsigned *a, const unsigned *b, int *c, size_t M,
                     popcount(bitwise_xor(a_imag, b_real));
       }
 
+      sum_real = 2 * (K_PADDED - sum_real);
+      sum_imag = 2 * (K_PADDED - K_PADDING - sum_imag);
+
+      const int alpha_real = static_cast<int>(alpha.x);
+      const int alpha_imag = static_cast<int>(alpha.y);
+      const int beta_real = static_cast<int>(beta.x);
+      const int beta_imag = static_cast<int>(beta.y);
+
+      sum_real = alpha_real * sum_real - alpha_imag * sum_imag;
+      sum_imag = alpha_imag * sum_real + alpha_real * sum_imag;
+
       if (output_mem_order == ccglib::mma::row_major) {
-        c_view(0, m, n) = 2 * (K_PADDED - sum_real);
-        c_view(1, m, n) = 2 * (K_PADDED - K_PADDING - sum_imag);
+        const int c_real = c_view(0, m, n);
+        const int c_imag = c_view(1, m, n);
+        c_view(0, m, n) = sum_real + beta_real * c_real - beta_imag * c_imag;
+        c_view(1, m, n) = sum_imag + beta_imag * c_real + beta_real * c_imag;
       } else {
-        c_view(0, n, m) = 2 * (K_PADDED - sum_real);
-        c_view(1, n, m) = 2 * (K_PADDED - K_PADDING - sum_imag);
+        const int c_real = c_view(0, n, m);
+        const int c_imag = c_view(1, n, m);
+        c_view(0, n, m) = sum_real + beta_real * c_real - beta_imag * c_imag;
+        c_view(1, n, m) = sum_imag + beta_imag * c_real + beta_real * c_imag;
       }
     }
   }
@@ -189,43 +218,51 @@ void run_binary(const unsigned *a, const unsigned *b, int *c, size_t M,
 namespace ccglib::reference {
 
 void GEMM::Run(const half *a, const half *b, half *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::Run<half, half>(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::Run<half, half>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const half *a, const half *b, float *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::Run<half, float>(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::Run<half, float>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const float *a, const float *b, half *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::Run<float, half>(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::Run<float, half>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const bf16 *a, const bf16 *b, bf16 *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::Run<bf16, bf16>(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::Run<bf16, bf16>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const bf16 *a, const bf16 *b, float *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::Run<bf16, float>(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::Run<bf16, float>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const float *a, const float *b, bf16 *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::Run<float, bf16>(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::Run<float, bf16>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const float *a, const float *b, float *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::Run<float, float>(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::Run<float, float>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const unsigned *a, const unsigned *b, int *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order) {
-  ::run_binary(a, b, c, M, N, K, output_mem_order);
+               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
+               float2 beta) {
+  ::run_binary(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 } // end namespace ccglib::reference

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -205,8 +205,9 @@ void run_binary(const unsigned *a, const unsigned *b, int *c, size_t M,
       const int beta_real = static_cast<int>(beta.x);
       const int beta_imag = static_cast<int>(beta.y);
 
+      const int sum_real_copy = sum_real;
       sum_real = alpha_real * sum_real - alpha_imag * sum_imag;
-      sum_imag = alpha_imag * sum_real + alpha_real * sum_imag;
+      sum_imag = alpha_imag * sum_real_copy + alpha_real * sum_imag;
 
       if (output_mem_order == ccglib::mma::row_major) {
         const int c_real = c_view(0, m, n);

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -69,25 +69,21 @@ void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
         sum_real = alpha_real * sum_real - alpha_imag * sum_imag;
         sum_imag = alpha_imag * sum_real_copy + alpha_real * sum_imag;
       }
-      if (output_mem_order == ccglib::mma::row_major) {
-        if (beta_real != 0 || beta_imag != 0) {
-          const ComputeType c_real = c_view(0, m, n);
-          const ComputeType c_imag = c_view(1, m, n);
-          sum_real += beta_real * c_real - beta_imag * c_imag;
-          sum_imag += beta_imag * c_real + beta_real * c_imag;
-        }
-        c_view(0, m, n) = sum_real;
-        c_view(1, m, n) = sum_imag;
-      } else {
-        if (beta_real != 0 || beta_imag != 0) {
-          const ComputeType c_real = c_view(0, n, m);
-          const ComputeType c_imag = c_view(1, n, m);
-          sum_real += beta_real * c_real - beta_imag * c_imag;
-          sum_imag += beta_imag * c_real + beta_real * c_imag;
-        }
-        c_view(0, n, m) = sum_real;
-        c_view(1, n, m) = sum_imag;
+
+      const size_t idx_major =
+          (output_mem_order == ccglib::mma::row_major) ? m : n;
+      const size_t idx_minor =
+          (output_mem_order == ccglib::mma::row_major) ? n : m;
+
+      if (beta_real != 0 || beta_imag != 0) {
+        const ComputeType c_real = c_view(0, idx_major, idx_minor);
+        const ComputeType c_imag = c_view(1, idx_major, idx_minor);
+        sum_real += beta_real * c_real - beta_imag * c_imag;
+        sum_imag += beta_imag * c_real + beta_real * c_imag;
       }
+
+      c_view(0, idx_major, idx_minor) = sum_real;
+      c_view(1, idx_major, idx_minor) = sum_imag;
     }
   }
 }

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -14,7 +14,8 @@
 namespace {
 template <typename Tin, typename Tout>
 void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
-         ccglib::mma::MemOrder output_mem_order, float2 alpha, float2 beta) {
+         ccglib::mma::MemOrder output_mem_order, std::complex<float> alpha,
+         std::complex<float> beta) {
   // Use float as the compute type when Tout is half or bf16 because tensor core
   // multiply-add operations execute in float precision. Otherwise, preserve
   // Tout.
@@ -58,10 +59,10 @@ void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
         sum_imag += term_imag;
       }
 
-      const ComputeType alpha_real = alpha.x;
-      const ComputeType alpha_imag = alpha.y;
-      const ComputeType beta_real = beta.x;
-      const ComputeType beta_imag = beta.y;
+      const ComputeType alpha_real = alpha.real();
+      const ComputeType alpha_imag = alpha.imag();
+      const ComputeType beta_real = beta.real();
+      const ComputeType beta_imag = beta.imag();
 
       if (alpha_real != 1 || alpha_imag != 0) {
         const ComputeType sum_real_copy = sum_real;
@@ -106,7 +107,7 @@ template <typename T> inline int popcount(T x) {
 
 void run_binary(const unsigned *a, const unsigned *b, int *c, size_t M,
                 size_t N, size_t K, ccglib::mma::MemOrder output_mem_order,
-                float2 alpha, float2 beta) {
+                std::complex<float> alpha, std::complex<float> beta) {
   // M, N, K are the number of 1-bit samples
   // the actual shape of the input data is different along the fastest changing
   // axis (=K) because values are packed into unsigned ints
@@ -200,10 +201,10 @@ void run_binary(const unsigned *a, const unsigned *b, int *c, size_t M,
       sum_real = 2 * (K_PADDED - sum_real);
       sum_imag = 2 * (K_PADDED - K_PADDING - sum_imag);
 
-      const int alpha_real = static_cast<int>(alpha.x);
-      const int alpha_imag = static_cast<int>(alpha.y);
-      const int beta_real = static_cast<int>(beta.x);
-      const int beta_imag = static_cast<int>(beta.y);
+      const int alpha_real = static_cast<int>(alpha.real());
+      const int alpha_imag = static_cast<int>(alpha.imag());
+      const int beta_real = static_cast<int>(beta.real());
+      const int beta_imag = static_cast<int>(beta.imag());
 
       const int sum_real_copy = sum_real;
       sum_real = alpha_real * sum_real - alpha_imag * sum_imag;
@@ -228,50 +229,50 @@ void run_binary(const unsigned *a, const unsigned *b, int *c, size_t M,
 namespace ccglib::reference {
 
 void GEMM::Run(const half *a, const half *b, half *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::Run<half, half>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const half *a, const half *b, float *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::Run<half, float>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const float *a, const float *b, half *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::Run<float, half>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const bf16 *a, const bf16 *b, bf16 *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::Run<bf16, bf16>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const bf16 *a, const bf16 *b, float *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::Run<bf16, float>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const float *a, const float *b, bf16 *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::Run<float, bf16>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const float *a, const float *b, float *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::Run<float, float>(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 
 void GEMM::Run(const unsigned *a, const unsigned *b, int *c, size_t M, size_t N,
-               size_t K, ccglib::mma::MemOrder output_mem_order, float2 alpha,
-               float2 beta) {
+               size_t K, ccglib::mma::MemOrder output_mem_order,
+               std::complex<float> alpha, std::complex<float> beta) {
   ::run_binary(a, b, c, M, N, K, output_mem_order, alpha, beta);
 }
 

--- a/src/reference/GEMM.cpp
+++ b/src/reference/GEMM.cpp
@@ -63,20 +63,29 @@ void Run(const Tin *a, const Tin *b, Tout *c, size_t M, size_t N, size_t K,
       const ComputeType beta_real = beta.x;
       const ComputeType beta_imag = beta.y;
 
-      const ComputeType sum_real_copy = sum_real;
-      sum_real = alpha_real * sum_real - alpha_imag * sum_imag;
-      sum_imag = alpha_imag * sum_real_copy + alpha_real * sum_imag;
-
+      if (alpha_real != 1 || alpha_imag != 0) {
+        const ComputeType sum_real_copy = sum_real;
+        sum_real = alpha_real * sum_real - alpha_imag * sum_imag;
+        sum_imag = alpha_imag * sum_real_copy + alpha_real * sum_imag;
+      }
       if (output_mem_order == ccglib::mma::row_major) {
-        const ComputeType c_real = c_view(0, m, n);
-        const ComputeType c_imag = c_view(1, m, n);
-        c_view(0, m, n) = sum_real + beta_real * c_real - beta_imag * c_imag;
-        c_view(1, m, n) = sum_imag + beta_imag * c_real + beta_real * c_imag;
+        if (beta_real != 0 || beta_imag != 0) {
+          const ComputeType c_real = c_view(0, m, n);
+          const ComputeType c_imag = c_view(1, m, n);
+          sum_real += beta_real * c_real - beta_imag * c_imag;
+          sum_imag += beta_imag * c_real + beta_real * c_imag;
+        }
+        c_view(0, m, n) = sum_real;
+        c_view(1, m, n) = sum_imag;
       } else {
-        const ComputeType c_real = c_view(0, n, m);
-        const ComputeType c_imag = c_view(1, n, m);
-        c_view(0, n, m) = sum_real + beta_real * c_real - beta_imag * c_imag;
-        c_view(1, n, m) = sum_imag + beta_imag * c_real + beta_real * c_imag;
+        if (beta_real != 0 || beta_imag != 0) {
+          const ComputeType c_real = c_view(0, n, m);
+          const ComputeType c_imag = c_view(1, n, m);
+          sum_real += beta_real * c_real - beta_imag * c_imag;
+          sum_imag += beta_imag * c_real + beta_real * c_imag;
+        }
+        c_view(0, n, m) = sum_real;
+        c_view(1, n, m) = sum_imag;
       }
     }
   }

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -597,8 +597,8 @@ TEST_CASE("Unsupported matrix layout") {
 
 TEST_CASE("Alpha/beta scaling") {
   const size_t batch_size = 16;
-  const size_t m = 16;
-  const size_t n = 64;
+  const size_t m = GENERATE(255, 256); // aligned and padded case
+  const size_t n = 128;
   const size_t k = 256;
 
   cu::init();

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -1,3 +1,4 @@
+#include <complex>
 #include <limits.h>
 #include <math.h>
 
@@ -609,8 +610,8 @@ TEST_CASE("Alpha/beta scaling") {
   SECTION("float16") {
     using Tin = half;
     using Tout = float;
-    const float2 alpha = {0.3, 1.6};
-    const float2 beta = {0.8, -1.1};
+    const std::complex<float> alpha = {0.3, 1.6};
+    const std::complex<float> beta = {0.8, -1.1};
 
     ccglib::mma::GEMM gemm(
         batch_size, m, n, k, device, stream,
@@ -669,8 +670,8 @@ TEST_CASE("Alpha/beta scaling") {
     }
     using Tin = unsigned int;
     using Tout = int;
-    const float2 alpha = {2, -3};
-    const float2 beta = {3, -2};
+    const std::complex<float> alpha = {2, -3};
+    const std::complex<float> beta = {3, -2};
 
     ccglib::mma::GEMM gemm(batch_size, m, n, k, device, stream,
                            {ccglib::ValueType::int1, ccglib::ValueType::int32},

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -677,8 +677,6 @@ TEST_CASE("Alpha/beta scaling") {
     using Tout = int;
     const std::complex<float> alpha = {2, -3};
     const std::complex<float> beta = {3, -2};
-    // const std::complex<float> alpha = {1, 0};
-    // const std::complex<float> beta = {0, 0};
 
     ccglib::mma::GEMM gemm(batch_size, m, n, k, device, stream,
                            {ccglib::ValueType::int1, ccglib::ValueType::int32},

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -663,11 +663,14 @@ TEST_CASE("Alpha/beta scaling") {
         ccglib::mma::row_major, alpha, beta, static_cast<Tout *>(h_c_in));
   }
 
-#if !defined(__HIP_PLATFORM_AMD__)
   SECTION("int1") {
+#ifdef __HIP_PLATFORM_AMD__
+    SKIP("int1 is not available on AMD GPUs");
+#endif
     if (isVolta(device)) {
       SKIP("Int1 is not available on Volta GPUs");
     }
+
     using Tin = unsigned int;
     using Tout = int;
     const std::complex<float> alpha = {2, -3};
@@ -682,9 +685,9 @@ TEST_CASE("Alpha/beta scaling") {
     const size_t bits_per_sample = sizeof(Tin) * CHAR_BIT;
     const size_t k_packed = ccglib::helper::ceildiv(k, bits_per_sample);
 
-    const size_t bytes_a = batch_size * COMPLEX * m * k_packed;
-    const size_t bytes_b = batch_size * COMPLEX * n * k_packed;
-    const size_t bytes_c = batch_size * COMPLEX * m * n;
+    const size_t bytes_a = batch_size * COMPLEX * m * k_packed * sizeof(Tin);
+    const size_t bytes_b = batch_size * COMPLEX * n * k_packed * sizeof(Tin);
+    const size_t bytes_c = batch_size * COMPLEX * m * n * sizeof(Tout);
 
     cu::HostMemory h_a(bytes_a);
     cu::HostMemory h_b(bytes_b);
@@ -722,7 +725,6 @@ TEST_CASE("Alpha/beta scaling") {
         static_cast<Tout *>(h_c_out), batch_size, m, n, k,
         ccglib::mma::row_major, alpha, beta, static_cast<Tout *>(h_c_in));
   }
-#endif
 }
 
 } // namespace ccglib::test

--- a/test/gemm/mma.cpp
+++ b/test/gemm/mma.cpp
@@ -618,9 +618,9 @@ TEST_CASE("Alpha/beta scaling") {
         ccglib::mma::basic, ccglib::complex_planar, ccglib::mma::row_major,
         ccglib::mma::row_major, ccglib::mma::col_major, alpha, beta);
 
-    const size_t bytes_a = COMPLEX * m * k * sizeof(Tin);
-    const size_t bytes_b = COMPLEX * n * k * sizeof(Tin);
-    const size_t bytes_c = COMPLEX * m * n * sizeof(Tout);
+    const size_t bytes_a = batch_size * COMPLEX * m * k * sizeof(Tin);
+    const size_t bytes_b = batch_size * COMPLEX * n * k * sizeof(Tin);
+    const size_t bytes_c = batch_size * COMPLEX * m * n * sizeof(Tout);
 
     cu::HostMemory h_a(bytes_a);
     cu::HostMemory h_b(bytes_b);

--- a/test/gemm/reference.cpp
+++ b/test/gemm/reference.cpp
@@ -87,4 +87,27 @@ TEST_CASE("Reference complex binary") {
   REQUIRE(c_ref_col_major == c_test);
 }
 
+TEST_CASE("Reference alpha/beta scaling") {
+  const size_t M = 2;
+  const size_t N = 2;
+  const size_t K = 8;
+  const size_t COMPLEX = 2;
+  const float2 alpha = {0.5, 2.5};
+  const float2 beta = {0.25, -1.5};
+
+  const half a[COMPLEX * M * K] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                                   11, 12, 13, 14, 15, 16, 15, 14, 13, 12, 11,
+                                   10, 9,  8,  7,  6,  5,  4,  3,  2,  1};
+  const half b[COMPLEX * N * K] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                                   11, 12, 13, 14, 15, 16, 15, 14, 13, 12, 11,
+                                   10, 9,  8,  7,  6,  5,  4,  3,  2,  1};
+  std::array<float, COMPLEX * M * N> c_test = {0, 1, 2, 3, 4, 3, 2, 1};
+  const std::array<float, COMPLEX * M * N> c_ref = {
+      -2110, -3039.25, -3040.5, -1409.75, -2571, 275.25, 273.5, 2607.75};
+
+  ccglib::reference::GEMM gemm;
+  gemm.Run(a, b, &c_test[0], M, N, K, ccglib::mma::row_major, alpha, beta);
+  REQUIRE(c_ref == c_test);
+}
+
 } // namespace ccglib::test

--- a/test/gemm/reference.cpp
+++ b/test/gemm/reference.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <complex>
 #include <limits.h>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xcomplex.hpp>
@@ -93,8 +94,8 @@ TEST_CASE("Reference alpha/beta scaling") {
     const size_t N = 2;
     const size_t K = 8;
     const size_t COMPLEX = 2;
-    const float2 alpha = {0.5, 2.5};
-    const float2 beta = {0.25, -1.5};
+    const std::complex<float> alpha = {0.5, 2.5};
+    const std::complex<float> beta = {0.25, -1.5};
 
     const half a[COMPLEX * M * K] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
                                      11, 12, 13, 14, 15, 16, 15, 14, 13, 12, 11,
@@ -116,8 +117,8 @@ TEST_CASE("Reference alpha/beta scaling") {
     const size_t N = 2;
     const size_t K = 32;
     const size_t COMPLEX = 2;
-    const float2 alpha = {2, 3};
-    const float2 beta = {-1, 2};
+    const std::complex<float> alpha = {2, 3};
+    const std::complex<float> beta = {-1, 2};
     const size_t bits_per_sample = sizeof(unsigned) * CHAR_BIT;
     const size_t K_PACKED = ccglib::helper::ceildiv(K, bits_per_sample);
 

--- a/test/gemm/reference.cpp
+++ b/test/gemm/reference.cpp
@@ -88,26 +88,52 @@ TEST_CASE("Reference complex binary") {
 }
 
 TEST_CASE("Reference alpha/beta scaling") {
-  const size_t M = 2;
-  const size_t N = 2;
-  const size_t K = 8;
-  const size_t COMPLEX = 2;
-  const float2 alpha = {0.5, 2.5};
-  const float2 beta = {0.25, -1.5};
+  SECTION("float16") {
+    const size_t M = 2;
+    const size_t N = 2;
+    const size_t K = 8;
+    const size_t COMPLEX = 2;
+    const float2 alpha = {0.5, 2.5};
+    const float2 beta = {0.25, -1.5};
 
-  const half a[COMPLEX * M * K] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-                                   11, 12, 13, 14, 15, 16, 15, 14, 13, 12, 11,
-                                   10, 9,  8,  7,  6,  5,  4,  3,  2,  1};
-  const half b[COMPLEX * N * K] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-                                   11, 12, 13, 14, 15, 16, 15, 14, 13, 12, 11,
-                                   10, 9,  8,  7,  6,  5,  4,  3,  2,  1};
-  std::array<float, COMPLEX * M * N> c_test = {0, 1, 2, 3, 4, 3, 2, 1};
-  const std::array<float, COMPLEX * M * N> c_ref = {
-      -2110, -3039.25, -3040.5, -1409.75, -2571, 275.25, 273.5, 2607.75};
+    const half a[COMPLEX * M * K] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                                     11, 12, 13, 14, 15, 16, 15, 14, 13, 12, 11,
+                                     10, 9,  8,  7,  6,  5,  4,  3,  2,  1};
+    const half b[COMPLEX * N * K] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                                     11, 12, 13, 14, 15, 16, 15, 14, 13, 12, 11,
+                                     10, 9,  8,  7,  6,  5,  4,  3,  2,  1};
+    std::array<float, COMPLEX * M * N> c_test = {0, 1, 2, 3, 4, 3, 2, 1};
+    const std::array<float, COMPLEX * M * N> c_ref = {
+        -2110, -3039.25, -3040.5, -1409.75, -2571, 275.25, 273.5, 2607.75};
 
-  ccglib::reference::GEMM gemm;
-  gemm.Run(a, b, &c_test[0], M, N, K, ccglib::mma::row_major, alpha, beta);
-  REQUIRE(c_ref == c_test);
+    ccglib::reference::GEMM gemm;
+    gemm.Run(a, b, &c_test[0], M, N, K, ccglib::mma::row_major, alpha, beta);
+    REQUIRE(c_ref == c_test);
+  }
+
+  SECTION("int1") {
+    const size_t M = 2;
+    const size_t N = 2;
+    const size_t K = 32;
+    const size_t COMPLEX = 2;
+    const float2 alpha = {2, 3};
+    const float2 beta = {-1, 2};
+    const size_t bits_per_sample = sizeof(unsigned) * CHAR_BIT;
+    const size_t K_PACKED = ccglib::helper::ceildiv(K, bits_per_sample);
+
+    const auto a = new unsigned[COMPLEX * M * K_PACKED]{4007499276, 2587246816,
+                                                        2368114480, 2180517764};
+    const auto b = new unsigned[COMPLEX * N * K_PACKED]{3172811225, 4156143586,
+                                                        144478092, 808068269};
+
+    std::array<int, COMPLEX * M * N> c_test = {1, 2, 3, 4, 5, 6, 7, 8};
+    const std::array<int, COMPLEX * M * N> c_ref = {-51, 38, -19, -50,
+                                                    -11, -2, -43, -6};
+
+    ccglib::reference::GEMM gemm;
+    gemm.Run(a, b, &c_test[0], M, N, K, ccglib::mma::row_major, alpha, beta);
+    REQUIRE(c_ref == c_test);
+  }
 }
 
 } // namespace ccglib::test

--- a/test/gemm/verify.h
+++ b/test/gemm/verify.h
@@ -1,6 +1,7 @@
 #ifndef VERIFY_H_
 #define VERIFY_H_
 
+#include <complex>
 #include <limits.h>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xtensor.hpp>
@@ -14,8 +15,8 @@
 template <typename Tin, typename Tout, ccglib::ValueType InputPrecision>
 void verify(const Tin *a, const Tin *b, const Tout *c_test, size_t B, size_t M,
             size_t N, size_t K, ccglib::mma::MemOrder output_mem_order,
-            float2 alpha = {1, 0}, float2 beta = {0, 0},
-            const Tout *c_in = nullptr) {
+            std::complex<float> alpha = {1, 0},
+            std::complex<float> beta = {0, 0}, const Tout *c_in = nullptr) {
   const size_t kPackingFactor =
       sizeof(Tin) * CHAR_BIT /
       ccglib::ValuePrecision{InputPrecision}.GetBitWidth();
@@ -39,7 +40,7 @@ void verify(const Tin *a, const Tin *b, const Tout *c_test, size_t B, size_t M,
 
   xt::xtensor<Tout, 4> c_ref(c_shape);
   if (c_in == nullptr) {
-    if (beta.x != 0 || beta.y != 0) {
+    if (beta.real() != 0 || beta.imag() != 0) {
       throw std::runtime_error("c_in must be given as argument when beta != 0");
     }
     c_ref = xt::zeros_like(c_test_view);

--- a/test/hip/mma.cpp
+++ b/test/hip/mma.cpp
@@ -25,13 +25,17 @@ TEST_CASE("HIP mma") {
   const size_t global_k = 512;
   const size_t batch_size = 3;
   const size_t COMPLEX = 2;
+  const float alpha = 1;
+  const float beta = 5;
 
   using Tin = half;
   using Tout = float;
 
   ccglib::mma::GEMM gemm(batch_size, global_m, global_n, global_k, device,
-                         stream, ccglib::ValueType::float16,
-                         ccglib::mma::basic);
+                         stream, ccglib::ValueType::float16, ccglib::mma::basic,
+                         ccglib::complex_planar, ccglib::mma::row_major,
+                         ccglib::mma::row_major, ccglib::mma::col_major, alpha,
+                         beta);
 
   const size_t bytes_a =
       sizeof(Tin) * batch_size * COMPLEX * global_m * global_k;
@@ -64,8 +68,13 @@ TEST_CASE("HIP mma") {
     h_b[i] = static_cast<Tin>(1);
   }
 
+  for (size_t i = 0; i < batch_size * COMPLEX * global_m * global_n; i++) {
+    h_c[i] = static_cast<Tout>(1);
+  }
+
   hip_check(hipMemcpy(d_a, h_a, bytes_a, hipMemcpyHostToDevice));
   hip_check(hipMemcpy(d_b, h_b, bytes_b, hipMemcpyHostToDevice));
+  hip_check(hipMemcpy(d_c, h_c, bytes_c, hipMemcpyHostToDevice));
 
   gemm.Run(reinterpret_cast<hipDeviceptr_t>(d_a),
            reinterpret_cast<hipDeviceptr_t>(d_b),
@@ -77,8 +86,8 @@ TEST_CASE("HIP mma") {
   // the imaginary part
   for (size_t i = 0; i < batch_size * COMPLEX * global_m * global_n; i++) {
     const size_t index = i % (global_m * global_n);
-    const Tout expected_value =
-        index < global_m * global_n ? 0.0f : 2.0f * global_k;
+    Tout expected_value = index < global_m * global_n ? 0.0f : 2.0f * global_k;
+    expected_value = alpha * expected_value + beta;
     ccglib::test::fpEquals(h_c[index], expected_value);
   }
 

--- a/test/pipeline/pipeline.cpp
+++ b/test/pipeline/pipeline.cpp
@@ -174,7 +174,7 @@ TEST_CASE("Pipeline int1 - int32") {
   ccglib::pipeline::Pipeline pipeline(
       B, M, N, K, device, stream, input_complex_axis_location,
       output_complex_axis_location, a_mem_order, b_mem_order, c_mem_order,
-      input_precision, output_precision, variant);
+      input_precision, output_precision, variant, alpha, beta);
 
   pipeline.Run(d_a, d_b, d_c);
   stream.memcpyDtoHAsync(h_c_out, d_c, d_c.size());

--- a/test/pipeline/pipeline.cpp
+++ b/test/pipeline/pipeline.cpp
@@ -1,5 +1,6 @@
 
 #include <catch2/catch_test_macros.hpp>
+#include <complex>
 #include <cudawrappers/cu.hpp>
 #include <functional>
 #include <limits.h>
@@ -18,6 +19,8 @@ TEST_CASE("Pipeline float16 - float32") {
   const size_t M = 300;
   const size_t N = 200;
   const size_t K = 100;
+  const std::complex<float> alpha = {1.5, -1.5};
+  const std::complex<float> beta = {0.5, -0.5};
 
   using Tin = half;
   using Tout = float;
@@ -43,7 +46,8 @@ TEST_CASE("Pipeline float16 - float32") {
 
   cu::HostMemory h_a(num_a * sizeof(Tin));
   cu::HostMemory h_b(num_b * sizeof(Tin));
-  cu::HostMemory h_c(num_c * sizeof(Tout));
+  cu::HostMemory h_c_in(num_c * sizeof(Tout));
+  cu::HostMemory h_c_out(num_c * sizeof(Tout));
 
   auto generator = std::bind(std::uniform_real_distribution<float>(-10, 10),
                              std::default_random_engine());
@@ -55,25 +59,30 @@ TEST_CASE("Pipeline float16 - float32") {
     static_cast<Tin *>(h_b)[i] = generator();
   }
 
+  for (int i = 0; i < num_c; i++) {
+    static_cast<Tout *>(h_c_in)[i] = generator();
+  }
+
   cu::DeviceMemory d_a(h_a.size());
   cu::DeviceMemory d_b(h_b.size());
-  cu::DeviceMemory d_c(h_c.size());
+  cu::DeviceMemory d_c(h_c_in.size());
   stream.memcpyHtoDAsync(d_a, h_a, d_a.size());
   stream.memcpyHtoDAsync(d_b, h_b, d_b.size());
-  d_c.zero(d_c.size());
+  stream.memcpyHtoDAsync(d_c, h_c_in, d_c.size());
 
   ccglib::pipeline::Pipeline pipeline(
       B, M, N, K, device, stream, input_complex_axis_location,
       output_complex_axis_location, a_mem_order, b_mem_order, c_mem_order,
-      input_precision, output_precision, variant);
+      input_precision, output_precision, variant, alpha, beta);
 
   pipeline.Run(d_a, d_b, d_c);
-  stream.memcpyDtoHAsync(h_c, d_c, d_c.size());
+  stream.memcpyDtoHAsync(h_c_out, d_c, d_c.size());
   stream.synchronize();
 
   verify<Tin, Tout, input_precision>(
       static_cast<const Tin *>(h_a), static_cast<const Tin *>(h_b),
-      static_cast<Tout *>(h_c), B, M, N, K, c_mem_order);
+      static_cast<Tout *>(h_c_out), B, M, N, K, c_mem_order, alpha, beta,
+      static_cast<Tout *>(h_c_in));
 }
 
 TEST_CASE("Pipeline int1 - int32") {
@@ -85,6 +94,8 @@ TEST_CASE("Pipeline int1 - int32") {
   const size_t M = 512;
   const size_t N = 512;
   const size_t K = 512;
+  const std::complex<float> alpha = {2, 3};
+  const std::complex<float> beta = {1, -3};
 
   using Tin = unsigned char;
   using Tpacked = unsigned;
@@ -112,6 +123,7 @@ TEST_CASE("Pipeline int1 - int32") {
       sizeof(Tpacked) *
       ccglib::helper::ceildiv(num_b / CHAR_BIT, sizeof(Tpacked));
   const size_t bytes_b = bytes_b_packed * CHAR_BIT;
+  const size_t bytes_c = num_c * sizeof(Tout);
 
   cu::init();
   cu::Device device(0);
@@ -120,7 +132,8 @@ TEST_CASE("Pipeline int1 - int32") {
 
   cu::HostMemory h_a_packed(bytes_a_packed);
   cu::HostMemory h_b_packed(bytes_b_packed);
-  cu::HostMemory h_c(num_c * sizeof(Tout));
+  cu::HostMemory h_c_in(bytes_c);
+  cu::HostMemory h_c_out(bytes_c);
 
   // the reference GEMM used in output verification does not support packing.
   // As a workaround, we generate random packed data and use the unpacking
@@ -134,6 +147,10 @@ TEST_CASE("Pipeline int1 - int32") {
 
   for (int i = 0; i < bytes_b_packed / sizeof(Tpacked); i++) {
     static_cast<Tpacked *>(h_b_packed)[i] = generator();
+  }
+
+  for (int i = 0; i < bytes_c / sizeof(Tout); i++) {
+    static_cast<Tout *>(h_c_in)[i] = generator();
   }
 
   cu::DeviceMemory d_a_packed(h_a_packed.size());
@@ -151,8 +168,8 @@ TEST_CASE("Pipeline int1 - int32") {
   unpack_a.Run(d_a_packed, d_a);
   unpack_b.Run(d_b_packed, d_b);
 
-  cu::DeviceMemory d_c(h_c.size());
-  d_c.zero(d_c.size());
+  cu::DeviceMemory d_c(h_c_in.size());
+  stream.memcpyHtoDAsync(d_c, h_c_in, d_c.size());
 
   ccglib::pipeline::Pipeline pipeline(
       B, M, N, K, device, stream, input_complex_axis_location,
@@ -160,13 +177,13 @@ TEST_CASE("Pipeline int1 - int32") {
       input_precision, output_precision, variant);
 
   pipeline.Run(d_a, d_b, d_c);
-  stream.memcpyDtoHAsync(h_c, d_c, d_c.size());
+  stream.memcpyDtoHAsync(h_c_out, d_c, d_c.size());
   stream.synchronize();
 
   verify<Tpacked, Tout, input_precision>(
       static_cast<const Tpacked *>(h_a_packed),
-      static_cast<const Tpacked *>(h_b_packed), static_cast<Tout *>(h_c), B, M,
-      N, K, c_mem_order);
+      static_cast<const Tpacked *>(h_b_packed), static_cast<Tout *>(h_c_out), B,
+      M, N, K, c_mem_order, alpha, beta, static_cast<Tout *>(h_c_in));
 }
 
 } // namespace ccglib::test


### PR DESCRIPTION
A full GEMM would be `D = alpha * A * B + beta * C`, however we only supported `C = A * B` so far. I have added scaling with the alpha/beta factors, while still assuming we write to C: `C = alpha * A * B + beta * C`;

Alpha and beta are given as complex float values, and casted to int as necessary for the integer kernels. 

To Do:
- [x] Implement in `store_matrix_padded`.
- [x] Add test for int1.
- [x] Figure out why the implemented test for the MMA kernel fails.
- [x] Add support to `Pipeline` class