### PR TITLE
Add explicit check for unsupported architectures

### DIFF
--- a/include/ccglib/common/arch.h
+++ b/include/ccglib/common/arch.h
@@ -16,13 +16,17 @@ bool isCDNA2(cu::Device &device) {
 
 bool isCDNA3(cu::Device &device) {
   const std::string arch(device.getArch());
-  return ((arch.find("gfx940") != std::string::npos) ||
-          (arch.find("gfx941") != std::string::npos) ||
-          (arch.find("gfx942") != std::string::npos));
+  return (arch.find("gfx94") != std::string::npos);
+}
+
+bool isCDNA4(cu::Device &device) {
+  const std::string arch(device.getArch());
+  return (arch.find("gfx95") != std::string::npos);
 }
 
 bool isCDNA(cu::Device &device) {
-  return (isCDNA1(device) || isCDNA2(device) || isCDNA3(device));
+  return (isCDNA1(device) || isCDNA2(device) || isCDNA3(device) ||
+          isCDNA4(device));
 }
 
 bool isVolta(cu::Device &device) {
@@ -30,6 +34,28 @@ bool isVolta(cu::Device &device) {
   return (arch.find("sm_70") != std::string::npos);
 }
 
+bool isUnsupported(cu::Device &device) {
+  const std::string arch(device.getArch());
+  // AMD: unsupported are gfx < 8, Vega gfx9, RDNA2=gfx10
+#if defined(__HIP_PLATFORM_AMD__)
+  if (arch.find("gfx6") != std::string::npos)
+    return true;
+  if (arch.find("gfx7") != std::string::npos)
+    return true;
+  if (arch.find("gfx8") != std::string::npos)
+    return true;
+  if ((arch.find("gfx9") != std::string::npos) && !isCDNA(device))
+    return true;
+  if (arch.find("gfx10") != std::string::npos)
+    return true;
+#else
+  // NVIDIA: older than Volta is not supported
+  const int arch_numeric = std::stoi(arch.substr(3));
+  if (arch_numeric < 70)
+    return true;
+#endif
+  return false;
+}
 } // namespace ccglib
 
 #endif // ARCH_H_

--- a/src/mma/GEMM.cpp
+++ b/src/mma/GEMM.cpp
@@ -109,6 +109,9 @@ void GEMM::Impl::check_support() {
       throw std::runtime_error("Float32 input is not supported on Volta");
     }
   }
+  if (isUnsupported(device_)) {
+    throw std::runtime_error("This architecture is not supported");
+  }
 }
 
 void GEMM::Impl::compile_kernel() {


### PR DESCRIPTION
I opted for a blacklist-based approach, as newer architectures may work without changes (e.g. RDNA4/Blackwell).
For AMD we do have to check if a gfx9 device is CDNA or Vega and there still is a whitelist for CDNA. Not sure we can get around that unless we hardcode the full list of Vega gfx9 devices (which I can do if that is preferred). For now I added CDNA4 to the whitelist just to be safe, that is probably the last CDNA generation anyway.

Very ancient AMD GPUs will not be recognised by this check, but those are not supported by ROCm at all so should pose no issue.

Closes #32 