### PR TITLE
Change CUDA workflow GPU to AD4000

### DIFF
--- a/.github/workflows/test_cuda.yml
+++ b/.github/workflows/test_cuda.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astron-rd/slurm-action@v1.1
         with:
-          partition: defq
+          partition: fatq
           gres: gpu:AD4000
           time: "00:10:00"
           commands: |


### PR DESCRIPTION
Since the A4000 (Ampere architecture) does not support FP8, select the RTX 4000 gpu based on the Ada architecture.