### PR TITLE
Fix: incorrect float8e4m3 kernel settings

### DIFF
--- a/src/mma/KernelFloat8.cpp
+++ b/src/mma/KernelFloat8.cpp
@@ -13,8 +13,8 @@ Kernel::Parameters Kernel::GetCompileParameters<ValueType::float8e4m3>() const {
   // format. To be consistent with the rest of the code, it is temporarily
   // disabled.
   // clang-format off
-  return Kernel::Parameters{.m_per_block = 256,
-                            .m_per_warp = 64,
+  return Kernel::Parameters{.m_per_block = 128,
+                            .m_per_warp = 32,
                             .m_per_wmma = 16,
 
                             .n_per_block = 32,


### PR DESCRIPTION
Due to a misconfigured kernel configuration, the amount of allocated shared memory could exceed the amount of available device memory, causing a run time exception. Fixes #41.