### PR TITLE
Use nvrtc::findIncludePaths

### DIFF
--- a/src/packing/Packing.cpp
+++ b/src/packing/Packing.cpp
@@ -74,8 +74,6 @@ void Packing::Impl::Run(cu::DeviceMemory &d_input, cu::DeviceMemory &d_output) {
 }
 
 void Packing::Impl::compile_kernel() {
-  const std::string cuda_include_path = nvrtc::findIncludePath();
-
   const std::string arch = device_.getArch();
   const unsigned warp_size =
       device_.getAttribute(CU_DEVICE_ATTRIBUTE_WARP_SIZE);
@@ -91,13 +89,15 @@ void Packing::Impl::compile_kernel() {
     // HIP does not enable warp sync functions by default (yet) in ROCm 6.x
     "-DHIP_ENABLE_WARP_SYNC_BUILTINS",
 #endif
-    "-I" + cuda_include_path,
-#if CUDA_VERSION >= 13000
-    "-I" + cuda_include_path + "/cccl",
-#endif
     "-DN_GLOBAL=" + std::to_string(N_) + "UL",
     "-DWARP_SIZE=" + std::to_string(warp_size)
   };
+
+  const std::vector<std::string> cuda_include_paths = nvrtc::findIncludePaths();
+
+  for (const auto &path : cuda_include_paths) {
+    options.push_back("-I" + path);
+  }
 
   if (input_complex_axis_location_ == ComplexAxisLocation::complex_planar) {
     options.push_back("-DINPUT_COMPLEX_PLANAR");


### PR DESCRIPTION
As a follow-up of #52, use the `nvrtc::findIncludePaths` to pull all required nvrtc include paths.