### PR TITLE
Fix CMake for installation of library and header files

### DIFF
--- a/.github/workflows/tune_cuda.yml
+++ b/.github/workflows/tune_cuda.yml
@@ -16,11 +16,11 @@ jobs:
           gres: gpu:A4000
           time: "00:10:00"
           commands: |
-            module load spack/20250403
-            module load cuda/12
+            module load spack/20251001-rocky8
+            module load cuda/13
             module load python
             python -m venv env
             source env/bin/activate
             pip install kernel_tuner
-            pip install cupy-cuda12x
+            pip install cupy-cuda13x
             python tuning/tune_gemm.py --name test -m 1024 -n 1024 -k 64 --type_in float16 --type_out float32 --backend cupy --m_per_block 16 --n_per_block 16

--- a/.github/workflows/tune_cuda.yml
+++ b/.github/workflows/tune_cuda.yml
@@ -21,6 +21,6 @@ jobs:
             module load python
             python -m venv env
             source env/bin/activate
-            pip install kernel_tuner==1.3.1
+            pip install kernel_tuner
             pip install cupy-cuda12x
             python tuning/tune_gemm.py --name test -m 1024 -n 1024 -k 64 --type_in float16 --type_out float32 --backend cupy --m_per_block 16 --n_per_block 16

--- a/.github/workflows/tune_cuda.yml
+++ b/.github/workflows/tune_cuda.yml
@@ -21,6 +21,6 @@ jobs:
             module load python
             python -m venv env
             source env/bin/activate
-            pip install kernel_tuner
+            pip install kernel_tuner==1.3.1
             pip install cupy-cuda12x
             python tuning/tune_gemm.py --name test -m 1024 -n 1024 -k 64 --type_in float16 --type_out float32 --backend cupy --m_per_block 16 --n_per_block 16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Let CMake install libraries and header files ([#57](https://github.com/nlesc-recruit/ccglib/pull/57)
+- Update CI tune_cuda workflow for latest Kernel Tuner ([#57](https://github.com/nlesc-recruit/ccglib/pull/57)
 
 ## [0.2.0] - 2026-02-05
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,4 +30,11 @@ target_embed_source(ccglib ../kernels/gemm_kernel_int1.cu)
 target_embed_source(ccglib ../kernels/transpose_kernel.cu)
 target_embed_source(ccglib ../kernels/packing_kernel.cu)
 
-target_include_directories(ccglib INTERFACE ${CCGLIB_INCLUDE_DIR})
+target_include_directories(
+  ccglib PUBLIC $<BUILD_INTERFACE:${CCGLIB_INCLUDE_DIR}>
+                $<INSTALL_INTERFACE:include>)
+
+install(TARGETS ccglib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(DIRECTORY "${CCGLIB_INCLUDE_DIR}/ccglib"
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,8 @@ target_embed_source(ccglib ../kernels/gemm_kernel_int1.cu)
 target_embed_source(ccglib ../kernels/transpose_kernel.cu)
 target_embed_source(ccglib ../kernels/packing_kernel.cu)
 
+include(GNUInstallDirs)
+
 target_include_directories(
   ccglib PUBLIC $<BUILD_INTERFACE:${CCGLIB_INCLUDE_DIR}>
                 $<INSTALL_INTERFACE:include>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ include(GNUInstallDirs)
 
 target_include_directories(
   ccglib PUBLIC $<BUILD_INTERFACE:${CCGLIB_INCLUDE_DIR}>
-                $<INSTALL_INTERFACE:include>)
+                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 install(TARGETS ccglib LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/tuning/tune_gemm.py
+++ b/tuning/tune_gemm.py
@@ -313,12 +313,9 @@ if __name__ == "__main__":
         "-std=c++17",
     ]
 
-    def restrict(*args):
+    def restrict(*args, **kwargs):
         param_names = list(tune_params.keys())
-        assert len(args) == len(param_names)
-        p = {}
-        for i in range(len(param_names)):
-            p[param_names[i]] = args[i]
+        p = {param_names[i]: args[i] for i in range(len(param_names))}
 
         n_per_warp = int(p["N_PER_BLOCK"] // p["block_size_y"])
         m_per_warp = int(p["M_PER_BLOCK"] // p["block_size_z"])


### PR DESCRIPTION
When integrating `ccglib` into another repository,  it now automatically installs the ccglib libraries and header files.